### PR TITLE
Fix: SQLAlchemy query, alembic.ini parser, Pydantic v2 validator

### DIFF
--- a/alembic.ini.example
+++ b/alembic.ini.example
@@ -43,7 +43,8 @@ version_locations = %(here)s/alembic/versions
 # version_path_separator = :
 # version_path_separator = ;
 # version_path_separator = space
-version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
+# Use os.pathsep. Default configuration used for new projects.
+version_path_separator = os
 
 # Database URL
 # Set this to your database URL or use environment variable

--- a/bot/database/manager.py
+++ b/bot/database/manager.py
@@ -317,7 +317,7 @@ class DatabaseManager(LoggerMixin):
         async with self.session() as session:
             query = select(GridLevel).where(GridLevel.bot_id == bot_id)
             if active_only:
-                query = query.where(GridLevel.is_active is True)
+                query = query.where(GridLevel.is_active.is_(True))
             query = query.order_by(GridLevel.level)
             result = await session.execute(query)
             return list(result.scalars().all())


### PR DESCRIPTION
## Summary

Fixes 3 bugs found during PR #117 review and deployment:

- **#118** — `GridLevel.is_active is True` replaced with `.is_(True)` for correct SQLAlchemy SQL generation
- **#119** — Inline comment in `alembic.ini.example` moved to separate line to fix INI parser error
- **#120** — `@field_validator("strategy")` replaced with `@model_validator(mode="after")` for Pydantic v2 compatibility

## Changes

| File | Fix |
|------|-----|
| `bot/database/manager.py` | `is True` → `.is_(True)` |
| `alembic.ini.example` | Inline comment → separate line |
| `bot/config/schemas.py` | `field_validator` → `model_validator(mode="after")` |

## Test plan

- [ ] Verify `get_bot_grid_levels()` returns active grid levels correctly
- [ ] Verify `alembic upgrade head` runs without parser errors
- [ ] Verify `configs/example.yaml` loads successfully with bots configured

Fixes #118, #119, #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)