### PR TITLE
feat: Grid Risk Manager — stop-loss, drawdown, trend deactivation (#157)

### DIFF
--- a/bot/strategies/grid/__init__.py
+++ b/bot/strategies/grid/__init__.py
@@ -12,6 +12,13 @@ from bot.strategies.grid.grid_order_manager import (
     GridOrderState,
     OrderStatus,
 )
+from bot.strategies.grid.grid_risk_manager import (
+    GridRiskAction,
+    GridRiskConfig,
+    GridRiskManager,
+    RiskCheckResult,
+    TrendState,
+)
 
 __all__ = [
     "GridCalculator",
@@ -22,4 +29,9 @@ __all__ = [
     "GridOrderState",
     "GridCycle",
     "OrderStatus",
+    "GridRiskManager",
+    "GridRiskConfig",
+    "GridRiskAction",
+    "RiskCheckResult",
+    "TrendState",
 ]

--- a/bot/strategies/grid/grid_risk_manager.py
+++ b/bot/strategies/grid/grid_risk_manager.py
@@ -1,0 +1,520 @@
+"""
+GridRiskManager — Risk management for grid trading strategy.
+
+Responsibilities:
+- Position size limits (per-grid and total exposure)
+- Grid-wide stop-loss
+- Trend detection for grid deactivation
+- Drawdown monitoring
+- Exposure and PnL thresholds
+"""
+
+from dataclasses import dataclass, field
+from decimal import Decimal, ROUND_HALF_UP
+from enum import Enum
+from typing import Any
+
+from bot.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# =============================================================================
+# Enums & Configuration
+# =============================================================================
+
+
+class GridRiskAction(str, Enum):
+    """Actions the risk manager can recommend."""
+
+    CONTINUE = "continue"
+    PAUSE = "pause"  # pause new orders, keep existing
+    REDUCE = "reduce"  # cancel some orders
+    STOP_LOSS = "stop_loss"  # close all, grid-wide stop
+    DEACTIVATE = "deactivate"  # deactivate grid (trending market)
+
+
+class TrendState(str, Enum):
+    """Market trend classification for grid suitability."""
+
+    RANGING = "ranging"  # ideal for grid
+    MILD_TREND = "mild_trend"  # acceptable
+    STRONG_TREND = "strong_trend"  # should deactivate
+
+
+@dataclass
+class GridRiskConfig:
+    """Configuration for grid risk management."""
+
+    # Position size limits
+    max_position_size: Decimal = Decimal("1000")  # max quote per single order
+    max_total_exposure: Decimal = Decimal("10000")  # max total quote across all orders
+    max_open_orders: int = 50  # max simultaneous open orders
+
+    # Stop-loss
+    grid_stop_loss_pct: Decimal = Decimal("0.05")  # 5% grid-wide SL
+    max_unrealized_loss: Decimal = Decimal("500")  # absolute max loss
+
+    # Drawdown limits
+    max_drawdown_pct: Decimal = Decimal("0.10")  # 10% max drawdown from peak
+    max_consecutive_losses: int = 5
+
+    # Trend detection thresholds
+    trend_atr_multiplier: Decimal = Decimal("2.0")  # price move > N*ATR = trending
+    trend_adx_threshold: float = 25.0  # ADX > threshold = trending
+
+    # Balance protection
+    min_balance_pct: Decimal = Decimal("0.20")  # keep 20% of balance free
+
+    def validate(self) -> None:
+        if self.max_position_size <= 0:
+            raise ValueError("max_position_size must be positive")
+        if self.max_total_exposure <= 0:
+            raise ValueError("max_total_exposure must be positive")
+        if self.max_open_orders < 1:
+            raise ValueError("max_open_orders must be at least 1")
+        if self.grid_stop_loss_pct <= 0:
+            raise ValueError("grid_stop_loss_pct must be positive")
+        if self.max_drawdown_pct <= 0 or self.max_drawdown_pct > 1:
+            raise ValueError("max_drawdown_pct must be between 0 and 1")
+        if self.min_balance_pct < 0 or self.min_balance_pct > 1:
+            raise ValueError("min_balance_pct must be between 0 and 1")
+
+
+# =============================================================================
+# Risk Check Result
+# =============================================================================
+
+
+@dataclass
+class RiskCheckResult:
+    """Result of a risk evaluation."""
+
+    action: GridRiskAction
+    reasons: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def is_safe(self) -> bool:
+        return self.action == GridRiskAction.CONTINUE
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action.value,
+            "is_safe": self.is_safe,
+            "reasons": self.reasons,
+            "warnings": self.warnings,
+        }
+
+
+# =============================================================================
+# Grid Risk Manager
+# =============================================================================
+
+
+class GridRiskManager:
+    """
+    Manages risk for grid trading strategy.
+
+    Evaluates position sizes, exposure, stop-loss triggers,
+    drawdown, and market conditions to determine if grid should continue.
+    """
+
+    def __init__(self, config: GridRiskConfig | None = None) -> None:
+        self._config = config or GridRiskConfig()
+        self._config.validate()
+
+        # State tracking
+        self._peak_equity = Decimal("0")
+        self._consecutive_losses = 0
+        self._grid_entry_price = Decimal("0")  # price when grid was activated
+        self._total_realized_pnl = Decimal("0")
+
+        logger.info("GridRiskManager initialized")
+
+    @property
+    def config(self) -> GridRiskConfig:
+        return self._config
+
+    # =================================================================
+    # Position Size Validation
+    # =================================================================
+
+    def validate_order_size(
+        self,
+        order_quote_value: Decimal,
+        current_total_exposure: Decimal,
+        current_open_orders: int,
+    ) -> RiskCheckResult:
+        """
+        Validate whether a new order can be placed.
+
+        Args:
+            order_quote_value: Quote currency value of the new order.
+            current_total_exposure: Current total exposure across all orders.
+            current_open_orders: Current number of open orders.
+
+        Returns:
+            RiskCheckResult with action and reasons.
+        """
+        result = RiskCheckResult(action=GridRiskAction.CONTINUE)
+
+        if order_quote_value > self._config.max_position_size:
+            result.action = GridRiskAction.PAUSE
+            result.reasons.append(
+                f"Order size {order_quote_value} exceeds max {self._config.max_position_size}"
+            )
+
+        new_exposure = current_total_exposure + order_quote_value
+        if new_exposure > self._config.max_total_exposure:
+            result.action = GridRiskAction.PAUSE
+            result.reasons.append(
+                f"Total exposure {new_exposure} would exceed max {self._config.max_total_exposure}"
+            )
+
+        if current_open_orders >= self._config.max_open_orders:
+            result.action = GridRiskAction.PAUSE
+            result.reasons.append(
+                f"Open orders {current_open_orders} at max {self._config.max_open_orders}"
+            )
+
+        if not result.reasons:
+            # Add warnings for approaching limits
+            exposure_pct = float(new_exposure / self._config.max_total_exposure)
+            if exposure_pct > 0.8:
+                result.warnings.append(
+                    f"Exposure at {exposure_pct:.0%} of max"
+                )
+            orders_pct = current_open_orders / self._config.max_open_orders
+            if orders_pct > 0.8:
+                result.warnings.append(
+                    f"Open orders at {orders_pct:.0%} of max"
+                )
+
+        return result
+
+    # =================================================================
+    # Stop-Loss Check
+    # =================================================================
+
+    def check_grid_stop_loss(
+        self,
+        current_price: Decimal,
+        grid_entry_price: Decimal | None = None,
+        unrealized_pnl: Decimal = Decimal("0"),
+    ) -> RiskCheckResult:
+        """
+        Check if grid-wide stop-loss should trigger.
+
+        Triggers on:
+        1. Price moved beyond grid_stop_loss_pct from entry
+        2. Unrealized loss exceeds max_unrealized_loss
+
+        Args:
+            current_price: Current market price.
+            grid_entry_price: Price when grid was started (optional, uses stored).
+            unrealized_pnl: Current unrealized PnL.
+
+        Returns:
+            RiskCheckResult.
+        """
+        entry = grid_entry_price or self._grid_entry_price
+        result = RiskCheckResult(action=GridRiskAction.CONTINUE)
+
+        if entry > 0:
+            price_change_pct = abs(current_price - entry) / entry
+            if price_change_pct >= self._config.grid_stop_loss_pct:
+                result.action = GridRiskAction.STOP_LOSS
+                result.reasons.append(
+                    f"Price moved {float(price_change_pct):.2%} from entry "
+                    f"(limit: {float(self._config.grid_stop_loss_pct):.2%})"
+                )
+
+        if unrealized_pnl < 0 and abs(unrealized_pnl) >= self._config.max_unrealized_loss:
+            result.action = GridRiskAction.STOP_LOSS
+            result.reasons.append(
+                f"Unrealized loss {unrealized_pnl} exceeds max {self._config.max_unrealized_loss}"
+            )
+
+        return result
+
+    # =================================================================
+    # Drawdown Check
+    # =================================================================
+
+    def check_drawdown(
+        self, current_equity: Decimal
+    ) -> RiskCheckResult:
+        """
+        Check if drawdown from peak equity exceeds the limit.
+
+        Args:
+            current_equity: Current account equity.
+
+        Returns:
+            RiskCheckResult.
+        """
+        # Update peak
+        if current_equity > self._peak_equity:
+            self._peak_equity = current_equity
+
+        result = RiskCheckResult(action=GridRiskAction.CONTINUE)
+
+        if self._peak_equity > 0:
+            drawdown = (self._peak_equity - current_equity) / self._peak_equity
+            if drawdown >= self._config.max_drawdown_pct:
+                result.action = GridRiskAction.STOP_LOSS
+                result.reasons.append(
+                    f"Drawdown {float(drawdown):.2%} exceeds max "
+                    f"{float(self._config.max_drawdown_pct):.2%}"
+                )
+            elif drawdown >= self._config.max_drawdown_pct * Decimal("0.7"):
+                result.warnings.append(
+                    f"Drawdown {float(drawdown):.2%} approaching limit"
+                )
+
+        return result
+
+    # =================================================================
+    # Consecutive Loss Check
+    # =================================================================
+
+    def record_trade_result(self, profit: Decimal) -> None:
+        """Record a trade result for consecutive loss tracking."""
+        self._total_realized_pnl += profit
+        if profit < 0:
+            self._consecutive_losses += 1
+        else:
+            self._consecutive_losses = 0
+
+    def check_consecutive_losses(self) -> RiskCheckResult:
+        """Check if consecutive losses exceed the limit."""
+        result = RiskCheckResult(action=GridRiskAction.CONTINUE)
+        if self._consecutive_losses >= self._config.max_consecutive_losses:
+            result.action = GridRiskAction.PAUSE
+            result.reasons.append(
+                f"{self._consecutive_losses} consecutive losses "
+                f"(max: {self._config.max_consecutive_losses})"
+            )
+        return result
+
+    # =================================================================
+    # Trend Detection (Grid Deactivation)
+    # =================================================================
+
+    def check_trend_suitability(
+        self,
+        atr: Decimal,
+        price_move: Decimal,
+        adx: float | None = None,
+    ) -> RiskCheckResult:
+        """
+        Check if market conditions are suitable for grid trading.
+
+        Grid strategies work best in ranging markets. Strong trends
+        can cause one-sided fills and growing exposure.
+
+        Args:
+            atr: Current ATR value.
+            price_move: Absolute price change over ATR period.
+            adx: ADX value if available (optional).
+
+        Returns:
+            RiskCheckResult with DEACTIVATE if trending too strongly.
+        """
+        result = RiskCheckResult(action=GridRiskAction.CONTINUE)
+
+        # Check price move vs ATR
+        if atr > 0:
+            move_ratio = price_move / atr
+            if move_ratio >= self._config.trend_atr_multiplier:
+                result.action = GridRiskAction.DEACTIVATE
+                result.reasons.append(
+                    f"Price move {float(move_ratio):.1f}x ATR "
+                    f"(threshold: {float(self._config.trend_atr_multiplier):.1f}x)"
+                )
+
+        # Check ADX if available
+        if adx is not None and adx >= self._config.trend_adx_threshold:
+            if result.action != GridRiskAction.DEACTIVATE:
+                result.action = GridRiskAction.DEACTIVATE
+            result.reasons.append(
+                f"ADX {adx:.1f} exceeds threshold {self._config.trend_adx_threshold:.1f}"
+            )
+
+        # Warnings for mild trend
+        if result.action == GridRiskAction.CONTINUE:
+            if atr > 0:
+                move_ratio = price_move / atr
+                if move_ratio >= self._config.trend_atr_multiplier * Decimal("0.7"):
+                    result.warnings.append("Price approaching trend threshold")
+            if adx is not None and adx >= self._config.trend_adx_threshold * 0.7:
+                result.warnings.append("ADX approaching trend threshold")
+
+        return result
+
+    def classify_trend(
+        self,
+        atr: Decimal,
+        price_move: Decimal,
+        adx: float | None = None,
+    ) -> TrendState:
+        """
+        Classify current market trend state.
+
+        Args:
+            atr: Current ATR value.
+            price_move: Absolute price change.
+            adx: ADX value if available.
+
+        Returns:
+            TrendState classification.
+        """
+        if atr <= 0:
+            return TrendState.RANGING
+
+        move_ratio = price_move / atr
+
+        if move_ratio >= self._config.trend_atr_multiplier:
+            return TrendState.STRONG_TREND
+        if adx is not None and adx >= self._config.trend_adx_threshold:
+            return TrendState.STRONG_TREND
+
+        threshold_70 = self._config.trend_atr_multiplier * Decimal("0.7")
+        if move_ratio >= threshold_70:
+            return TrendState.MILD_TREND
+        if adx is not None and adx >= self._config.trend_adx_threshold * 0.7:
+            return TrendState.MILD_TREND
+
+        return TrendState.RANGING
+
+    # =================================================================
+    # Balance Protection
+    # =================================================================
+
+    def check_balance(
+        self,
+        available_balance: Decimal,
+        total_balance: Decimal,
+    ) -> RiskCheckResult:
+        """
+        Check if enough balance is kept free.
+
+        Args:
+            available_balance: Currently available (free) balance.
+            total_balance: Total account balance.
+
+        Returns:
+            RiskCheckResult.
+        """
+        result = RiskCheckResult(action=GridRiskAction.CONTINUE)
+
+        if total_balance <= 0:
+            result.action = GridRiskAction.PAUSE
+            result.reasons.append("Total balance is zero or negative")
+            return result
+
+        free_pct = available_balance / total_balance
+        if free_pct < self._config.min_balance_pct:
+            result.action = GridRiskAction.PAUSE
+            result.reasons.append(
+                f"Free balance {float(free_pct):.1%} below minimum "
+                f"{float(self._config.min_balance_pct):.1%}"
+            )
+
+        return result
+
+    # =================================================================
+    # Comprehensive Risk Evaluation
+    # =================================================================
+
+    def evaluate_risk(
+        self,
+        current_price: Decimal,
+        current_equity: Decimal,
+        current_exposure: Decimal,
+        open_orders: int,
+        unrealized_pnl: Decimal = Decimal("0"),
+        atr: Decimal = Decimal("0"),
+        price_move: Decimal = Decimal("0"),
+        adx: float | None = None,
+        available_balance: Decimal = Decimal("0"),
+        total_balance: Decimal = Decimal("0"),
+    ) -> RiskCheckResult:
+        """
+        Run all risk checks and return the most severe result.
+
+        Priority: STOP_LOSS > DEACTIVATE > REDUCE > PAUSE > CONTINUE
+
+        Returns:
+            RiskCheckResult with the highest-priority action.
+        """
+        checks = [
+            self.check_grid_stop_loss(current_price, unrealized_pnl=unrealized_pnl),
+            self.check_drawdown(current_equity),
+            self.check_consecutive_losses(),
+        ]
+
+        if atr > 0:
+            checks.append(self.check_trend_suitability(atr, price_move, adx))
+
+        if total_balance > 0:
+            checks.append(self.check_balance(available_balance, total_balance))
+
+        # Merge all results — pick most severe action
+        priority = {
+            GridRiskAction.CONTINUE: 0,
+            GridRiskAction.PAUSE: 1,
+            GridRiskAction.REDUCE: 2,
+            GridRiskAction.DEACTIVATE: 3,
+            GridRiskAction.STOP_LOSS: 4,
+        }
+
+        merged = RiskCheckResult(action=GridRiskAction.CONTINUE)
+        for check in checks:
+            if priority[check.action] > priority[merged.action]:
+                merged.action = check.action
+            merged.reasons.extend(check.reasons)
+            merged.warnings.extend(check.warnings)
+
+        if merged.reasons:
+            logger.warning(
+                "Risk check triggered",
+                action=merged.action.value,
+                reasons=merged.reasons,
+            )
+
+        return merged
+
+    # =================================================================
+    # State Management
+    # =================================================================
+
+    def set_grid_entry_price(self, price: Decimal) -> None:
+        """Set the entry price when grid is activated."""
+        self._grid_entry_price = price
+        self._peak_equity = Decimal("0")
+        self._consecutive_losses = 0
+
+    def reset(self) -> None:
+        """Reset all risk tracking state."""
+        self._peak_equity = Decimal("0")
+        self._consecutive_losses = 0
+        self._grid_entry_price = Decimal("0")
+        self._total_realized_pnl = Decimal("0")
+
+    def get_statistics(self) -> dict[str, Any]:
+        """Get risk manager statistics."""
+        return {
+            "peak_equity": str(self._peak_equity),
+            "consecutive_losses": self._consecutive_losses,
+            "grid_entry_price": str(self._grid_entry_price),
+            "total_realized_pnl": str(self._total_realized_pnl),
+            "config": {
+                "max_position_size": str(self._config.max_position_size),
+                "max_total_exposure": str(self._config.max_total_exposure),
+                "max_open_orders": self._config.max_open_orders,
+                "grid_stop_loss_pct": str(self._config.grid_stop_loss_pct),
+                "max_drawdown_pct": str(self._config.max_drawdown_pct),
+            },
+        }

--- a/tests/strategies/grid/test_grid_risk_manager.py
+++ b/tests/strategies/grid/test_grid_risk_manager.py
@@ -1,0 +1,468 @@
+"""Tests for GridRiskManager v2.0.
+
+Tests position limits, stop-loss, drawdown, trend detection, and comprehensive risk evaluation.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from bot.strategies.grid.grid_risk_manager import (
+    GridRiskAction,
+    GridRiskConfig,
+    GridRiskManager,
+    RiskCheckResult,
+    TrendState,
+)
+
+
+# =========================================================================
+# Fixtures
+# =========================================================================
+
+
+@pytest.fixture
+def config():
+    return GridRiskConfig(
+        max_position_size=Decimal("1000"),
+        max_total_exposure=Decimal("10000"),
+        max_open_orders=20,
+        grid_stop_loss_pct=Decimal("0.05"),
+        max_unrealized_loss=Decimal("500"),
+        max_drawdown_pct=Decimal("0.10"),
+        max_consecutive_losses=5,
+        trend_atr_multiplier=Decimal("2.0"),
+        trend_adx_threshold=25.0,
+        min_balance_pct=Decimal("0.20"),
+    )
+
+
+@pytest.fixture
+def manager(config):
+    return GridRiskManager(config=config)
+
+
+# =========================================================================
+# Config Validation Tests
+# =========================================================================
+
+
+class TestGridRiskConfig:
+    def test_defaults(self):
+        cfg = GridRiskConfig()
+        cfg.validate()  # should not raise
+
+    def test_invalid_position_size(self):
+        cfg = GridRiskConfig(max_position_size=Decimal("0"))
+        with pytest.raises(ValueError, match="max_position_size must be positive"):
+            cfg.validate()
+
+    def test_invalid_exposure(self):
+        cfg = GridRiskConfig(max_total_exposure=Decimal("-1"))
+        with pytest.raises(ValueError, match="max_total_exposure must be positive"):
+            cfg.validate()
+
+    def test_invalid_max_orders(self):
+        cfg = GridRiskConfig(max_open_orders=0)
+        with pytest.raises(ValueError, match="max_open_orders must be at least 1"):
+            cfg.validate()
+
+    def test_invalid_stop_loss(self):
+        cfg = GridRiskConfig(grid_stop_loss_pct=Decimal("0"))
+        with pytest.raises(ValueError, match="grid_stop_loss_pct must be positive"):
+            cfg.validate()
+
+    def test_invalid_drawdown(self):
+        cfg = GridRiskConfig(max_drawdown_pct=Decimal("1.5"))
+        with pytest.raises(ValueError, match="max_drawdown_pct must be between"):
+            cfg.validate()
+
+    def test_invalid_balance_pct(self):
+        cfg = GridRiskConfig(min_balance_pct=Decimal("-0.1"))
+        with pytest.raises(ValueError, match="min_balance_pct must be between"):
+            cfg.validate()
+
+
+# =========================================================================
+# RiskCheckResult Tests
+# =========================================================================
+
+
+class TestRiskCheckResult:
+    def test_is_safe_continue(self):
+        r = RiskCheckResult(action=GridRiskAction.CONTINUE)
+        assert r.is_safe is True
+
+    def test_is_not_safe_pause(self):
+        r = RiskCheckResult(action=GridRiskAction.PAUSE)
+        assert r.is_safe is False
+
+    def test_to_dict(self):
+        r = RiskCheckResult(
+            action=GridRiskAction.STOP_LOSS,
+            reasons=["price dropped"],
+            warnings=["approaching limit"],
+        )
+        d = r.to_dict()
+        assert d["action"] == "stop_loss"
+        assert d["is_safe"] is False
+        assert len(d["reasons"]) == 1
+        assert len(d["warnings"]) == 1
+
+
+# =========================================================================
+# Order Size Validation Tests
+# =========================================================================
+
+
+class TestOrderSizeValidation:
+    def test_valid_order(self, manager):
+        result = manager.validate_order_size(
+            Decimal("500"), Decimal("3000"), 10
+        )
+        assert result.is_safe
+        assert result.action == GridRiskAction.CONTINUE
+
+    def test_order_exceeds_max_size(self, manager):
+        result = manager.validate_order_size(
+            Decimal("1500"), Decimal("3000"), 10
+        )
+        assert not result.is_safe
+        assert "exceeds max" in result.reasons[0]
+
+    def test_exposure_exceeds_max(self, manager):
+        result = manager.validate_order_size(
+            Decimal("500"), Decimal("9800"), 10
+        )
+        assert not result.is_safe
+        assert "Total exposure" in result.reasons[0]
+
+    def test_max_open_orders(self, manager):
+        result = manager.validate_order_size(
+            Decimal("100"), Decimal("1000"), 20
+        )
+        assert not result.is_safe
+        assert "Open orders" in result.reasons[0]
+
+    def test_exposure_warning(self, manager):
+        result = manager.validate_order_size(
+            Decimal("100"), Decimal("8500"), 10
+        )
+        assert result.is_safe  # still within limits
+        assert len(result.warnings) > 0
+
+    def test_orders_warning(self, manager):
+        result = manager.validate_order_size(
+            Decimal("100"), Decimal("1000"), 17
+        )
+        assert result.is_safe
+        assert any("Open orders" in w for w in result.warnings)
+
+
+# =========================================================================
+# Stop-Loss Tests
+# =========================================================================
+
+
+class TestGridStopLoss:
+    def test_no_stop_loss(self, manager):
+        manager.set_grid_entry_price(Decimal("45000"))
+        result = manager.check_grid_stop_loss(Decimal("44500"))
+        # 500/45000 ≈ 1.1% < 5%
+        assert result.is_safe
+
+    def test_stop_loss_triggered_price_up(self, manager):
+        manager.set_grid_entry_price(Decimal("45000"))
+        # 5% above entry
+        result = manager.check_grid_stop_loss(Decimal("47300"))
+        assert result.action == GridRiskAction.STOP_LOSS
+
+    def test_stop_loss_triggered_price_down(self, manager):
+        manager.set_grid_entry_price(Decimal("45000"))
+        # 5% below entry
+        result = manager.check_grid_stop_loss(Decimal("42700"))
+        assert result.action == GridRiskAction.STOP_LOSS
+
+    def test_stop_loss_unrealized_loss(self, manager):
+        result = manager.check_grid_stop_loss(
+            Decimal("45000"), unrealized_pnl=Decimal("-600")
+        )
+        assert result.action == GridRiskAction.STOP_LOSS
+        assert "Unrealized loss" in result.reasons[0]
+
+    def test_no_entry_price_set(self, manager):
+        result = manager.check_grid_stop_loss(Decimal("45000"))
+        assert result.is_safe  # no entry price means no check
+
+    def test_explicit_entry_price(self, manager):
+        result = manager.check_grid_stop_loss(
+            Decimal("42000"), grid_entry_price=Decimal("45000")
+        )
+        # 3000/45000 ≈ 6.7% > 5%
+        assert result.action == GridRiskAction.STOP_LOSS
+
+
+# =========================================================================
+# Drawdown Tests
+# =========================================================================
+
+
+class TestDrawdown:
+    def test_no_drawdown(self, manager):
+        result = manager.check_drawdown(Decimal("10000"))
+        assert result.is_safe
+        assert manager._peak_equity == Decimal("10000")
+
+    def test_equity_increase(self, manager):
+        manager.check_drawdown(Decimal("10000"))
+        manager.check_drawdown(Decimal("11000"))
+        assert manager._peak_equity == Decimal("11000")
+
+    def test_drawdown_within_limit(self, manager):
+        manager.check_drawdown(Decimal("10000"))
+        result = manager.check_drawdown(Decimal("9500"))
+        # 5% drawdown < 10% limit
+        assert result.is_safe
+
+    def test_drawdown_exceeded(self, manager):
+        manager.check_drawdown(Decimal("10000"))
+        result = manager.check_drawdown(Decimal("8900"))
+        # 11% drawdown > 10% limit
+        assert result.action == GridRiskAction.STOP_LOSS
+
+    def test_drawdown_warning(self, manager):
+        manager.check_drawdown(Decimal("10000"))
+        result = manager.check_drawdown(Decimal("9250"))
+        # 7.5% ≥ 7% (70% of 10%)
+        assert result.is_safe
+        assert len(result.warnings) > 0
+
+
+# =========================================================================
+# Consecutive Loss Tests
+# =========================================================================
+
+
+class TestConsecutiveLosses:
+    def test_no_losses(self, manager):
+        result = manager.check_consecutive_losses()
+        assert result.is_safe
+
+    def test_losses_under_limit(self, manager):
+        for _ in range(4):
+            manager.record_trade_result(Decimal("-10"))
+        result = manager.check_consecutive_losses()
+        assert result.is_safe
+        assert manager._consecutive_losses == 4
+
+    def test_losses_at_limit(self, manager):
+        for _ in range(5):
+            manager.record_trade_result(Decimal("-10"))
+        result = manager.check_consecutive_losses()
+        assert result.action == GridRiskAction.PAUSE
+
+    def test_win_resets_counter(self, manager):
+        for _ in range(3):
+            manager.record_trade_result(Decimal("-10"))
+        manager.record_trade_result(Decimal("20"))  # win resets
+        assert manager._consecutive_losses == 0
+
+    def test_pnl_tracking(self, manager):
+        manager.record_trade_result(Decimal("100"))
+        manager.record_trade_result(Decimal("-30"))
+        assert manager._total_realized_pnl == Decimal("70")
+
+
+# =========================================================================
+# Trend Detection Tests
+# =========================================================================
+
+
+class TestTrendDetection:
+    def test_ranging_market(self, manager):
+        result = manager.check_trend_suitability(
+            atr=Decimal("500"), price_move=Decimal("300")
+        )
+        assert result.is_safe
+
+    def test_strong_trend_atr(self, manager):
+        result = manager.check_trend_suitability(
+            atr=Decimal("500"), price_move=Decimal("1200")
+        )
+        assert result.action == GridRiskAction.DEACTIVATE
+
+    def test_strong_trend_adx(self, manager):
+        result = manager.check_trend_suitability(
+            atr=Decimal("500"), price_move=Decimal("300"), adx=30.0
+        )
+        assert result.action == GridRiskAction.DEACTIVATE
+
+    def test_both_atr_and_adx_trending(self, manager):
+        result = manager.check_trend_suitability(
+            atr=Decimal("500"), price_move=Decimal("1200"), adx=35.0
+        )
+        assert result.action == GridRiskAction.DEACTIVATE
+        assert len(result.reasons) == 2  # both triggers
+
+    def test_mild_trend_warning(self, manager):
+        # 70% of threshold: 500*2*0.7 = 700
+        result = manager.check_trend_suitability(
+            atr=Decimal("500"), price_move=Decimal("750")
+        )
+        assert result.is_safe
+        assert len(result.warnings) > 0
+
+    def test_classify_ranging(self, manager):
+        state = manager.classify_trend(
+            atr=Decimal("500"), price_move=Decimal("300")
+        )
+        assert state == TrendState.RANGING
+
+    def test_classify_mild_trend(self, manager):
+        state = manager.classify_trend(
+            atr=Decimal("500"), price_move=Decimal("750")
+        )
+        assert state == TrendState.MILD_TREND
+
+    def test_classify_strong_trend(self, manager):
+        state = manager.classify_trend(
+            atr=Decimal("500"), price_move=Decimal("1200")
+        )
+        assert state == TrendState.STRONG_TREND
+
+    def test_classify_strong_trend_adx(self, manager):
+        state = manager.classify_trend(
+            atr=Decimal("500"), price_move=Decimal("300"), adx=30.0
+        )
+        assert state == TrendState.STRONG_TREND
+
+    def test_classify_zero_atr(self, manager):
+        state = manager.classify_trend(
+            atr=Decimal("0"), price_move=Decimal("300")
+        )
+        assert state == TrendState.RANGING
+
+
+# =========================================================================
+# Balance Protection Tests
+# =========================================================================
+
+
+class TestBalanceProtection:
+    def test_sufficient_balance(self, manager):
+        result = manager.check_balance(Decimal("3000"), Decimal("10000"))
+        assert result.is_safe
+
+    def test_insufficient_free_balance(self, manager):
+        result = manager.check_balance(Decimal("1500"), Decimal("10000"))
+        # 15% < 20%
+        assert result.action == GridRiskAction.PAUSE
+
+    def test_zero_balance(self, manager):
+        result = manager.check_balance(Decimal("0"), Decimal("0"))
+        assert result.action == GridRiskAction.PAUSE
+
+    def test_exact_threshold(self, manager):
+        result = manager.check_balance(Decimal("2000"), Decimal("10000"))
+        # 20% == 20% — not below
+        assert result.is_safe
+
+
+# =========================================================================
+# Comprehensive Risk Evaluation Tests
+# =========================================================================
+
+
+class TestEvaluateRisk:
+    def test_all_clear(self, manager):
+        manager.set_grid_entry_price(Decimal("45000"))
+        result = manager.evaluate_risk(
+            current_price=Decimal("45000"),
+            current_equity=Decimal("10000"),
+            current_exposure=Decimal("5000"),
+            open_orders=10,
+            available_balance=Decimal("5000"),
+            total_balance=Decimal("10000"),
+        )
+        assert result.is_safe
+
+    def test_stop_loss_priority(self, manager):
+        manager.set_grid_entry_price(Decimal("45000"))
+        result = manager.evaluate_risk(
+            current_price=Decimal("42000"),  # >5% drop → stop loss
+            current_equity=Decimal("10000"),
+            current_exposure=Decimal("5000"),
+            open_orders=10,
+        )
+        assert result.action == GridRiskAction.STOP_LOSS
+
+    def test_deactivate_on_trend(self, manager):
+        manager.set_grid_entry_price(Decimal("45000"))
+        result = manager.evaluate_risk(
+            current_price=Decimal("45000"),
+            current_equity=Decimal("10000"),
+            current_exposure=Decimal("5000"),
+            open_orders=10,
+            atr=Decimal("500"),
+            price_move=Decimal("1200"),
+        )
+        assert result.action == GridRiskAction.DEACTIVATE
+
+    def test_stop_loss_overrides_deactivate(self, manager):
+        manager.set_grid_entry_price(Decimal("45000"))
+        result = manager.evaluate_risk(
+            current_price=Decimal("42000"),  # stop loss trigger
+            current_equity=Decimal("10000"),
+            current_exposure=Decimal("5000"),
+            open_orders=10,
+            atr=Decimal("500"),
+            price_move=Decimal("1200"),  # also trending
+        )
+        # Stop loss has higher priority than deactivate
+        assert result.action == GridRiskAction.STOP_LOSS
+
+    def test_multiple_warnings_merged(self, manager):
+        manager.set_grid_entry_price(Decimal("45000"))
+        manager.check_drawdown(Decimal("10000"))  # set peak
+        result = manager.evaluate_risk(
+            current_price=Decimal("45000"),
+            current_equity=Decimal("9300"),  # 7% DD → warning
+            current_exposure=Decimal("5000"),
+            open_orders=10,
+            atr=Decimal("500"),
+            price_move=Decimal("750"),  # mild trend → warning
+        )
+        assert result.is_safe
+        assert len(result.warnings) > 0
+
+
+# =========================================================================
+# State Management Tests
+# =========================================================================
+
+
+class TestStateManagement:
+    def test_set_grid_entry_price(self, manager):
+        manager.set_grid_entry_price(Decimal("45000"))
+        assert manager._grid_entry_price == Decimal("45000")
+
+    def test_reset(self, manager):
+        manager.set_grid_entry_price(Decimal("45000"))
+        manager.check_drawdown(Decimal("10000"))
+        manager.record_trade_result(Decimal("-50"))
+        manager.reset()
+        assert manager._peak_equity == Decimal("0")
+        assert manager._consecutive_losses == 0
+        assert manager._grid_entry_price == Decimal("0")
+        assert manager._total_realized_pnl == Decimal("0")
+
+    def test_statistics(self, manager):
+        manager.set_grid_entry_price(Decimal("45000"))
+        stats = manager.get_statistics()
+        assert stats["grid_entry_price"] == "45000"
+        assert stats["config"]["max_position_size"] == "1000"
+        assert stats["config"]["max_open_orders"] == 20
+
+    def test_default_config(self):
+        mgr = GridRiskManager()
+        assert mgr.config.max_position_size == Decimal("1000")


### PR DESCRIPTION
## Summary
- Implements `GridRiskManager` in `bot/strategies/grid/grid_risk_manager.py`
- Position size limits and total exposure caps
- Grid-wide stop-loss: price-based (% from entry) and absolute unrealized loss
- Drawdown monitoring with peak equity tracking
- Consecutive loss detection with auto-pause
- Trend suitability check via ATR ratio and ADX — deactivates grid in strong trends
- Balance protection: minimum free balance threshold
- `evaluate_risk()` merges all checks with priority: STOP_LOSS > DEACTIVATE > PAUSE > CONTINUE
- 55 unit tests covering all risk checks, config validation, and state management

## Test plan
- [x] All 55 new tests pass
- [x] All 151 grid tests pass (calculator + order manager + risk manager)

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)