### PR TITLE
feat: DCA Risk Manager with drawdown and pump protection (#161)

### DIFF
--- a/bot/strategies/dca/__init__.py
+++ b/bot/strategies/dca/__init__.py
@@ -1,4 +1,4 @@
-"""DCA Strategy Package — v2.0 Signal Generator, Position Manager, and related utilities."""
+"""DCA Strategy Package — v2.0 Signal Generator, Position Manager, Risk Manager."""
 
 from bot.strategies.dca.dca_signal_generator import (
     ConditionResult,
@@ -18,6 +18,14 @@ from bot.strategies.dca.dca_position_manager import (
     DealStatus,
     SafetyOrderLevel,
 )
+from bot.strategies.dca.dca_risk_manager import (
+    DCARiskAction,
+    DCARiskConfig,
+    DCARiskManager,
+    DealRiskState,
+    PortfolioRiskState,
+    RiskCheckResult,
+)
 
 __all__ = [
     "DCASignalGenerator",
@@ -34,4 +42,10 @@ __all__ = [
     "DCAOrderStatus",
     "SafetyOrderLevel",
     "CloseResult",
+    "DCARiskManager",
+    "DCARiskConfig",
+    "DCARiskAction",
+    "RiskCheckResult",
+    "DealRiskState",
+    "PortfolioRiskState",
 ]

--- a/bot/strategies/dca/dca_risk_manager.py
+++ b/bot/strategies/dca/dca_risk_manager.py
@@ -1,0 +1,610 @@
+"""
+DCA Risk Manager — v2.0.
+
+Controls risk for DCA operations:
+- Maximum drawdown limits (per-deal and portfolio)
+- Capital allocation and balance protection
+- Emergency stop-loss enforcement
+- Maximum concurrent positions
+- Daily loss limits
+- Pump & dump protection (extreme price change detection)
+- Consecutive loss tracking
+
+Usage:
+    config = DCARiskConfig(max_concurrent_deals=3, ...)
+    risk_mgr = DCARiskManager(config)
+    result = risk_mgr.evaluate_risk(state)
+    if not result.is_safe:
+        # Handle risk action
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
+
+# =============================================================================
+# Enums
+# =============================================================================
+
+
+class DCARiskAction(str, Enum):
+    """Risk action to take."""
+
+    CONTINUE = "continue"  # All clear
+    PAUSE = "pause"  # Temporarily stop opening new deals
+    CLOSE_DEAL = "close_deal"  # Close specific deal
+    CLOSE_ALL = "close_all"  # Emergency: close all deals
+    REDUCE = "reduce"  # Reduce position / skip next SO
+
+
+# =============================================================================
+# Data Structures
+# =============================================================================
+
+
+@dataclass
+class RiskCheckResult:
+    """Result of a risk check."""
+
+    action: DCARiskAction = DCARiskAction.CONTINUE
+    reasons: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def is_safe(self) -> bool:
+        return self.action == DCARiskAction.CONTINUE
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action.value,
+            "is_safe": self.is_safe,
+            "reasons": self.reasons,
+            "warnings": self.warnings,
+        }
+
+
+@dataclass
+class DealRiskState:
+    """Risk-relevant state of a single deal."""
+
+    deal_id: str
+    symbol: str
+    entry_price: Decimal
+    average_entry_price: Decimal
+    current_price: Decimal
+    total_cost: Decimal
+    total_volume: Decimal
+    safety_orders_filled: int
+    max_safety_orders: int
+    unrealized_pnl: Decimal = Decimal("0")
+    unrealized_pnl_pct: Decimal = Decimal("0")
+
+
+@dataclass
+class PortfolioRiskState:
+    """Risk-relevant state of the entire DCA portfolio."""
+
+    active_deals: list[DealRiskState] = field(default_factory=list)
+    total_equity: Decimal = Decimal("0")
+    available_balance: Decimal = Decimal("0")
+    total_balance: Decimal = Decimal("0")
+    daily_realized_pnl: Decimal = Decimal("0")
+    consecutive_losses: int = 0
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+
+@dataclass
+class DCARiskConfig:
+    """Risk management configuration for DCA strategy."""
+
+    # Position limits
+    max_concurrent_deals: int = 3
+    max_position_cost: Decimal = Decimal("5000")  # Per deal
+    max_total_exposure: Decimal = Decimal("15000")  # All deals combined
+
+    # Stop loss
+    deal_stop_loss_pct: Decimal = Decimal("10.0")  # Per-deal SL from base price
+    deal_stop_loss_from_average: bool = False  # Measure from avg entry instead
+
+    # Drawdown
+    max_deal_drawdown_pct: Decimal = Decimal("15.0")  # Max unrealized loss per deal
+    max_portfolio_drawdown_pct: Decimal = Decimal("10.0")  # Max drawdown from peak
+
+    # Daily limits
+    max_daily_loss: Decimal = Decimal("500")
+    max_consecutive_losses: int = 5
+
+    # Balance protection
+    min_balance_pct: Decimal = Decimal("0.20")  # Keep at least 20% free
+
+    # Pump & dump protection
+    max_price_change_pct: Decimal = Decimal("10.0")  # Max % change to trigger alert
+    pause_on_extreme_volatility: bool = True
+
+    def validate(self) -> None:
+        """Validate configuration."""
+        if self.max_concurrent_deals < 1:
+            raise ValueError("max_concurrent_deals must be >= 1")
+        if self.max_position_cost <= 0:
+            raise ValueError("max_position_cost must be positive")
+        if self.max_total_exposure <= 0:
+            raise ValueError("max_total_exposure must be positive")
+        if self.deal_stop_loss_pct <= 0:
+            raise ValueError("deal_stop_loss_pct must be positive")
+        if self.max_deal_drawdown_pct <= 0 or self.max_deal_drawdown_pct > 100:
+            raise ValueError("max_deal_drawdown_pct must be between 0 and 100")
+        if self.max_portfolio_drawdown_pct <= 0 or self.max_portfolio_drawdown_pct > 100:
+            raise ValueError("max_portfolio_drawdown_pct must be between 0 and 100")
+        if self.max_daily_loss < 0:
+            raise ValueError("max_daily_loss must be >= 0")
+        if self.max_consecutive_losses < 1:
+            raise ValueError("max_consecutive_losses must be >= 1")
+        if self.min_balance_pct < 0 or self.min_balance_pct > 1:
+            raise ValueError("min_balance_pct must be between 0 and 1")
+        if self.max_price_change_pct <= 0:
+            raise ValueError("max_price_change_pct must be positive")
+
+
+# =============================================================================
+# DCA Risk Manager
+# =============================================================================
+
+
+class DCARiskManager:
+    """
+    Manages risk for DCA strategy.
+
+    Checks:
+    1. Concurrent deal limits
+    2. Per-deal stop-loss
+    3. Per-deal drawdown
+    4. Portfolio drawdown
+    5. Daily loss limits
+    6. Consecutive loss streaks
+    7. Balance protection
+    8. Extreme price movement (pump & dump)
+    """
+
+    def __init__(self, config: DCARiskConfig | None = None):
+        self._config = config or DCARiskConfig()
+        self._config.validate()
+        self._peak_equity = Decimal("0")
+        self._consecutive_losses = 0
+        self._total_realized_pnl = Decimal("0")
+        self._daily_realized_pnl = Decimal("0")
+
+    @property
+    def config(self) -> DCARiskConfig:
+        return self._config
+
+    # -----------------------------------------------------------------
+    # Full Risk Evaluation
+    # -----------------------------------------------------------------
+
+    def evaluate_risk(self, state: PortfolioRiskState) -> RiskCheckResult:
+        """
+        Run all risk checks and return the highest-priority action.
+
+        Priority: CLOSE_ALL > CLOSE_DEAL > REDUCE > PAUSE > CONTINUE.
+        """
+        all_reasons: list[str] = []
+        all_warnings: list[str] = []
+        highest_action = DCARiskAction.CONTINUE
+
+        # 1. Per-deal checks
+        for deal_state in state.active_deals:
+            deal_result = self.check_deal_risk(deal_state)
+            if not deal_result.is_safe:
+                all_reasons.extend(deal_result.reasons)
+                if self._action_priority(deal_result.action) > self._action_priority(highest_action):
+                    highest_action = deal_result.action
+            all_warnings.extend(deal_result.warnings)
+
+        # 2. Portfolio-level checks
+        checks = [
+            self.check_concurrent_deals(len(state.active_deals)),
+            self.check_portfolio_drawdown(state.total_equity),
+            self.check_daily_loss(state.daily_realized_pnl),
+            self.check_consecutive_losses(),
+            self.check_balance(state.available_balance, state.total_balance),
+            self.check_total_exposure(state.active_deals),
+        ]
+
+        for check in checks:
+            all_warnings.extend(check.warnings)
+            if not check.is_safe:
+                all_reasons.extend(check.reasons)
+                if self._action_priority(check.action) > self._action_priority(highest_action):
+                    highest_action = check.action
+
+        return RiskCheckResult(
+            action=highest_action,
+            reasons=all_reasons,
+            warnings=all_warnings,
+        )
+
+    # -----------------------------------------------------------------
+    # Individual Checks
+    # -----------------------------------------------------------------
+
+    def check_deal_risk(self, deal: DealRiskState) -> RiskCheckResult:
+        """Check risk for a single deal."""
+        reasons: list[str] = []
+        warnings: list[str] = []
+        action = DCARiskAction.CONTINUE
+
+        # Stop loss
+        sl_result = self.check_deal_stop_loss(deal)
+        if not sl_result.is_safe:
+            reasons.extend(sl_result.reasons)
+            action = sl_result.action
+        warnings.extend(sl_result.warnings)
+
+        # Drawdown
+        dd_result = self.check_deal_drawdown(deal)
+        if not dd_result.is_safe:
+            reasons.extend(dd_result.reasons)
+            if self._action_priority(dd_result.action) > self._action_priority(action):
+                action = dd_result.action
+        warnings.extend(dd_result.warnings)
+
+        return RiskCheckResult(action=action, reasons=reasons, warnings=warnings)
+
+    def check_deal_stop_loss(self, deal: DealRiskState) -> RiskCheckResult:
+        """Check if a deal has hit its stop-loss."""
+        cfg = self._config
+
+        if cfg.deal_stop_loss_from_average:
+            ref_price = deal.average_entry_price
+        else:
+            ref_price = deal.entry_price
+
+        if ref_price <= 0:
+            return RiskCheckResult()
+
+        loss_pct = ((ref_price - deal.current_price) / ref_price) * 100
+
+        if loss_pct >= cfg.deal_stop_loss_pct:
+            return RiskCheckResult(
+                action=DCARiskAction.CLOSE_DEAL,
+                reasons=[
+                    f"Deal {deal.deal_id}: Stop-loss triggered "
+                    f"({loss_pct:.1f}% >= {cfg.deal_stop_loss_pct}%)"
+                ],
+            )
+
+        # Warning at 70%
+        warning_threshold = cfg.deal_stop_loss_pct * Decimal("0.7")
+        if loss_pct >= warning_threshold:
+            return RiskCheckResult(
+                warnings=[
+                    f"Deal {deal.deal_id}: Approaching stop-loss "
+                    f"({loss_pct:.1f}% / {cfg.deal_stop_loss_pct}%)"
+                ],
+            )
+
+        return RiskCheckResult()
+
+    def check_deal_drawdown(self, deal: DealRiskState) -> RiskCheckResult:
+        """Check per-deal unrealized drawdown."""
+        cfg = self._config
+
+        if deal.total_cost <= 0:
+            return RiskCheckResult()
+
+        dd_pct = abs(deal.unrealized_pnl_pct) if deal.unrealized_pnl < 0 else Decimal("0")
+
+        if dd_pct >= cfg.max_deal_drawdown_pct:
+            return RiskCheckResult(
+                action=DCARiskAction.CLOSE_DEAL,
+                reasons=[
+                    f"Deal {deal.deal_id}: Drawdown exceeded "
+                    f"({dd_pct:.1f}% >= {cfg.max_deal_drawdown_pct}%)"
+                ],
+            )
+
+        warning_threshold = cfg.max_deal_drawdown_pct * Decimal("0.7")
+        if dd_pct >= warning_threshold:
+            return RiskCheckResult(
+                warnings=[
+                    f"Deal {deal.deal_id}: Drawdown warning "
+                    f"({dd_pct:.1f}% / {cfg.max_deal_drawdown_pct}%)"
+                ],
+            )
+
+        return RiskCheckResult()
+
+    def check_concurrent_deals(self, active_count: int) -> RiskCheckResult:
+        """Check if too many deals are open."""
+        cfg = self._config
+
+        if active_count >= cfg.max_concurrent_deals:
+            return RiskCheckResult(
+                action=DCARiskAction.PAUSE,
+                reasons=[
+                    f"Max concurrent deals reached ({active_count}/{cfg.max_concurrent_deals})"
+                ],
+            )
+
+        warning_at = max(1, cfg.max_concurrent_deals - 1)
+        if active_count >= warning_at:
+            return RiskCheckResult(
+                warnings=[
+                    f"Approaching max deals ({active_count}/{cfg.max_concurrent_deals})"
+                ],
+            )
+
+        return RiskCheckResult()
+
+    def check_portfolio_drawdown(self, current_equity: Decimal) -> RiskCheckResult:
+        """Track peak equity and check portfolio drawdown."""
+        cfg = self._config
+
+        if current_equity > self._peak_equity:
+            self._peak_equity = current_equity
+
+        if self._peak_equity <= 0:
+            return RiskCheckResult()
+
+        dd_pct = ((self._peak_equity - current_equity) / self._peak_equity) * 100
+
+        if dd_pct >= cfg.max_portfolio_drawdown_pct:
+            return RiskCheckResult(
+                action=DCARiskAction.CLOSE_ALL,
+                reasons=[
+                    f"Portfolio drawdown exceeded ({dd_pct:.1f}% >= {cfg.max_portfolio_drawdown_pct}%)"
+                ],
+            )
+
+        warning_threshold = cfg.max_portfolio_drawdown_pct * Decimal("0.7")
+        if dd_pct >= warning_threshold:
+            return RiskCheckResult(
+                warnings=[
+                    f"Portfolio drawdown warning ({dd_pct:.1f}% / {cfg.max_portfolio_drawdown_pct}%)"
+                ],
+            )
+
+        return RiskCheckResult()
+
+    def check_daily_loss(
+        self, daily_pnl: Decimal | None = None
+    ) -> RiskCheckResult:
+        """Check daily realized PnL limit."""
+        cfg = self._config
+        pnl = daily_pnl if daily_pnl is not None else self._daily_realized_pnl
+
+        if cfg.max_daily_loss > 0 and pnl < -cfg.max_daily_loss:
+            return RiskCheckResult(
+                action=DCARiskAction.PAUSE,
+                reasons=[
+                    f"Daily loss exceeded ({pnl} < -{cfg.max_daily_loss})"
+                ],
+            )
+
+        warning_threshold = -cfg.max_daily_loss * Decimal("0.7")
+        if cfg.max_daily_loss > 0 and pnl < warning_threshold:
+            return RiskCheckResult(
+                warnings=[
+                    f"Approaching daily loss limit ({pnl} / -{cfg.max_daily_loss})"
+                ],
+            )
+
+        return RiskCheckResult()
+
+    def check_consecutive_losses(self) -> RiskCheckResult:
+        """Check consecutive loss streak."""
+        cfg = self._config
+
+        if self._consecutive_losses >= cfg.max_consecutive_losses:
+            return RiskCheckResult(
+                action=DCARiskAction.PAUSE,
+                reasons=[
+                    f"Consecutive losses reached ({self._consecutive_losses} >= {cfg.max_consecutive_losses})"
+                ],
+            )
+
+        return RiskCheckResult()
+
+    def check_balance(
+        self, available_balance: Decimal, total_balance: Decimal
+    ) -> RiskCheckResult:
+        """Check minimum free balance threshold."""
+        cfg = self._config
+
+        if total_balance <= 0:
+            return RiskCheckResult(
+                action=DCARiskAction.PAUSE,
+                reasons=["Zero total balance"],
+            )
+
+        free_ratio = available_balance / total_balance
+        if free_ratio < cfg.min_balance_pct:
+            return RiskCheckResult(
+                action=DCARiskAction.PAUSE,
+                reasons=[
+                    f"Free balance too low ({free_ratio:.1%} < {cfg.min_balance_pct:.0%})"
+                ],
+            )
+
+        return RiskCheckResult()
+
+    def check_total_exposure(
+        self, deals: list[DealRiskState]
+    ) -> RiskCheckResult:
+        """Check total exposure across all deals."""
+        cfg = self._config
+        total_cost = sum(d.total_cost for d in deals)
+
+        if total_cost > cfg.max_total_exposure:
+            return RiskCheckResult(
+                action=DCARiskAction.PAUSE,
+                reasons=[
+                    f"Total exposure exceeded ({total_cost} > {cfg.max_total_exposure})"
+                ],
+            )
+
+        warning_threshold = cfg.max_total_exposure * Decimal("0.85")
+        if total_cost > warning_threshold:
+            return RiskCheckResult(
+                warnings=[
+                    f"Approaching exposure limit ({total_cost} / {cfg.max_total_exposure})"
+                ],
+            )
+
+        return RiskCheckResult()
+
+    def check_price_change(
+        self, previous_price: Decimal, current_price: Decimal
+    ) -> RiskCheckResult:
+        """
+        Check for extreme price movement (pump & dump protection).
+
+        Compares price change against max_price_change_pct threshold.
+        """
+        cfg = self._config
+
+        if previous_price <= 0:
+            return RiskCheckResult()
+
+        change_pct = abs((current_price - previous_price) / previous_price) * 100
+
+        if change_pct >= cfg.max_price_change_pct:
+            action = DCARiskAction.PAUSE if cfg.pause_on_extreme_volatility else DCARiskAction.CONTINUE
+            return RiskCheckResult(
+                action=action,
+                reasons=[
+                    f"Extreme price change ({change_pct:.1f}% >= {cfg.max_price_change_pct}%)"
+                ] if action != DCARiskAction.CONTINUE else [],
+                warnings=[
+                    f"Extreme price change detected ({change_pct:.1f}%)"
+                ] if action == DCARiskAction.CONTINUE else [],
+            )
+
+        return RiskCheckResult()
+
+    # -----------------------------------------------------------------
+    # State Tracking
+    # -----------------------------------------------------------------
+
+    def record_trade_result(self, pnl: Decimal) -> None:
+        """Record a completed trade result."""
+        self._total_realized_pnl += pnl
+        self._daily_realized_pnl += pnl
+        if pnl < 0:
+            self._consecutive_losses += 1
+        else:
+            self._consecutive_losses = 0
+
+    def reset_daily_pnl(self) -> None:
+        """Reset daily PnL counter (call at start of new trading day)."""
+        self._daily_realized_pnl = Decimal("0")
+
+    def reset(self) -> None:
+        """Reset all internal state."""
+        self._peak_equity = Decimal("0")
+        self._consecutive_losses = 0
+        self._total_realized_pnl = Decimal("0")
+        self._daily_realized_pnl = Decimal("0")
+
+    # -----------------------------------------------------------------
+    # Queries
+    # -----------------------------------------------------------------
+
+    def can_open_new_deal(
+        self,
+        active_deal_count: int,
+        deal_cost: Decimal,
+        current_exposure: Decimal,
+        available_balance: Decimal,
+        total_balance: Decimal,
+    ) -> RiskCheckResult:
+        """
+        Quick check whether a new deal can be opened.
+
+        Combines concurrent deal limit, exposure, and balance checks.
+        """
+        reasons: list[str] = []
+        warnings: list[str] = []
+        action = DCARiskAction.CONTINUE
+
+        # Concurrent deals
+        if active_deal_count >= self._config.max_concurrent_deals:
+            action = DCARiskAction.PAUSE
+            reasons.append(
+                f"Max concurrent deals ({active_deal_count}/{self._config.max_concurrent_deals})"
+            )
+
+        # Exposure
+        if current_exposure + deal_cost > self._config.max_total_exposure:
+            action = DCARiskAction.PAUSE
+            reasons.append(
+                f"Would exceed exposure limit ({current_exposure + deal_cost} > {self._config.max_total_exposure})"
+            )
+
+        # Single deal cost
+        if deal_cost > self._config.max_position_cost:
+            action = DCARiskAction.PAUSE
+            reasons.append(
+                f"Deal cost exceeds max ({deal_cost} > {self._config.max_position_cost})"
+            )
+
+        # Balance
+        if total_balance > 0:
+            remaining = available_balance - deal_cost
+            remaining_ratio = remaining / total_balance
+            if remaining_ratio < self._config.min_balance_pct:
+                action = DCARiskAction.PAUSE
+                reasons.append(
+                    f"Would leave insufficient balance ({remaining_ratio:.1%} < {self._config.min_balance_pct:.0%})"
+                )
+
+        # Daily loss
+        if self._config.max_daily_loss > 0 and self._daily_realized_pnl < -self._config.max_daily_loss:
+            action = DCARiskAction.PAUSE
+            reasons.append("Daily loss limit already exceeded")
+
+        # Consecutive losses
+        if self._consecutive_losses >= self._config.max_consecutive_losses:
+            action = DCARiskAction.PAUSE
+            reasons.append("Consecutive loss limit reached")
+
+        return RiskCheckResult(action=action, reasons=reasons, warnings=warnings)
+
+    def get_statistics(self) -> dict[str, Any]:
+        """Return current risk state for monitoring."""
+        return {
+            "peak_equity": str(self._peak_equity),
+            "consecutive_losses": self._consecutive_losses,
+            "total_realized_pnl": str(self._total_realized_pnl),
+            "daily_realized_pnl": str(self._daily_realized_pnl),
+            "config": {
+                "max_concurrent_deals": self._config.max_concurrent_deals,
+                "max_position_cost": str(self._config.max_position_cost),
+                "max_total_exposure": str(self._config.max_total_exposure),
+                "deal_stop_loss_pct": str(self._config.deal_stop_loss_pct),
+                "max_daily_loss": str(self._config.max_daily_loss),
+                "max_consecutive_losses": self._config.max_consecutive_losses,
+            },
+        }
+
+    # -----------------------------------------------------------------
+    # Internal
+    # -----------------------------------------------------------------
+
+    @staticmethod
+    def _action_priority(action: DCARiskAction) -> int:
+        """Higher number = higher priority."""
+        return {
+            DCARiskAction.CONTINUE: 0,
+            DCARiskAction.PAUSE: 1,
+            DCARiskAction.REDUCE: 2,
+            DCARiskAction.CLOSE_DEAL: 3,
+            DCARiskAction.CLOSE_ALL: 4,
+        }.get(action, 0)

--- a/tests/strategies/dca/test_dca_risk_manager.py
+++ b/tests/strategies/dca/test_dca_risk_manager.py
@@ -1,0 +1,652 @@
+"""Tests for DCA Risk Manager v2.0.
+
+Tests drawdown limits, capital allocation, emergency stop-loss,
+concurrent position limits, daily loss, and pump & dump protection.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from bot.strategies.dca.dca_risk_manager import (
+    DCARiskAction,
+    DCARiskConfig,
+    DCARiskManager,
+    DealRiskState,
+    PortfolioRiskState,
+    RiskCheckResult,
+)
+
+
+# =========================================================================
+# Fixtures
+# =========================================================================
+
+
+@pytest.fixture
+def config():
+    return DCARiskConfig(
+        max_concurrent_deals=3,
+        max_position_cost=Decimal("5000"),
+        max_total_exposure=Decimal("15000"),
+        deal_stop_loss_pct=Decimal("10.0"),
+        max_deal_drawdown_pct=Decimal("15.0"),
+        max_portfolio_drawdown_pct=Decimal("10.0"),
+        max_daily_loss=Decimal("500"),
+        max_consecutive_losses=5,
+        min_balance_pct=Decimal("0.20"),
+        max_price_change_pct=Decimal("10.0"),
+    )
+
+
+@pytest.fixture
+def manager(config):
+    return DCARiskManager(config)
+
+
+@pytest.fixture
+def safe_deal():
+    return DealRiskState(
+        deal_id="DCA-0001",
+        symbol="BTC/USDT",
+        entry_price=Decimal("3100"),
+        average_entry_price=Decimal("3050"),
+        current_price=Decimal("3000"),
+        total_cost=Decimal("1000"),
+        total_volume=Decimal("0.33"),
+        safety_orders_filled=1,
+        max_safety_orders=5,
+        unrealized_pnl=Decimal("-50"),
+        unrealized_pnl_pct=Decimal("-5.0"),
+    )
+
+
+@pytest.fixture
+def safe_portfolio(safe_deal):
+    return PortfolioRiskState(
+        active_deals=[safe_deal],
+        total_equity=Decimal("10000"),
+        available_balance=Decimal("5000"),
+        total_balance=Decimal("10000"),
+        daily_realized_pnl=Decimal("-100"),
+    )
+
+
+# =========================================================================
+# Config Validation Tests
+# =========================================================================
+
+
+class TestDCARiskConfig:
+    def test_defaults(self):
+        cfg = DCARiskConfig()
+        cfg.validate()
+
+    def test_invalid_concurrent_deals(self):
+        cfg = DCARiskConfig(max_concurrent_deals=0)
+        with pytest.raises(ValueError, match="max_concurrent_deals"):
+            cfg.validate()
+
+    def test_invalid_position_cost(self):
+        cfg = DCARiskConfig(max_position_cost=Decimal("0"))
+        with pytest.raises(ValueError, match="max_position_cost"):
+            cfg.validate()
+
+    def test_invalid_total_exposure(self):
+        cfg = DCARiskConfig(max_total_exposure=Decimal("-1"))
+        with pytest.raises(ValueError, match="max_total_exposure"):
+            cfg.validate()
+
+    def test_invalid_stop_loss(self):
+        cfg = DCARiskConfig(deal_stop_loss_pct=Decimal("0"))
+        with pytest.raises(ValueError, match="deal_stop_loss_pct"):
+            cfg.validate()
+
+    def test_invalid_deal_drawdown(self):
+        cfg = DCARiskConfig(max_deal_drawdown_pct=Decimal("101"))
+        with pytest.raises(ValueError, match="max_deal_drawdown_pct"):
+            cfg.validate()
+
+    def test_invalid_portfolio_drawdown(self):
+        cfg = DCARiskConfig(max_portfolio_drawdown_pct=Decimal("0"))
+        with pytest.raises(ValueError, match="max_portfolio_drawdown_pct"):
+            cfg.validate()
+
+    def test_invalid_daily_loss(self):
+        cfg = DCARiskConfig(max_daily_loss=Decimal("-1"))
+        with pytest.raises(ValueError, match="max_daily_loss"):
+            cfg.validate()
+
+    def test_invalid_consecutive_losses(self):
+        cfg = DCARiskConfig(max_consecutive_losses=0)
+        with pytest.raises(ValueError, match="max_consecutive_losses"):
+            cfg.validate()
+
+    def test_invalid_balance_pct(self):
+        cfg = DCARiskConfig(min_balance_pct=Decimal("1.5"))
+        with pytest.raises(ValueError, match="min_balance_pct"):
+            cfg.validate()
+
+    def test_invalid_price_change(self):
+        cfg = DCARiskConfig(max_price_change_pct=Decimal("0"))
+        with pytest.raises(ValueError, match="max_price_change_pct"):
+            cfg.validate()
+
+
+# =========================================================================
+# RiskCheckResult Tests
+# =========================================================================
+
+
+class TestRiskCheckResult:
+    def test_continue_is_safe(self):
+        r = RiskCheckResult()
+        assert r.is_safe is True
+
+    def test_pause_is_not_safe(self):
+        r = RiskCheckResult(action=DCARiskAction.PAUSE)
+        assert r.is_safe is False
+
+    def test_to_dict(self):
+        r = RiskCheckResult(
+            action=DCARiskAction.CLOSE_DEAL,
+            reasons=["stop loss"],
+            warnings=["warning"],
+        )
+        d = r.to_dict()
+        assert d["action"] == "close_deal"
+        assert d["is_safe"] is False
+        assert len(d["reasons"]) == 1
+
+
+# =========================================================================
+# Deal Stop Loss Tests
+# =========================================================================
+
+
+class TestDealStopLoss:
+    def test_no_stop_loss(self, manager):
+        deal = DealRiskState(
+            deal_id="D1", symbol="BTC", entry_price=Decimal("3100"),
+            average_entry_price=Decimal("3100"), current_price=Decimal("3000"),
+            total_cost=Decimal("1000"), total_volume=Decimal("0.32"),
+            safety_orders_filled=0, max_safety_orders=5,
+        )
+        result = manager.check_deal_stop_loss(deal)
+        assert result.is_safe  # ~3.2% < 10%
+
+    def test_stop_loss_triggered(self, manager):
+        deal = DealRiskState(
+            deal_id="D1", symbol="BTC", entry_price=Decimal("3100"),
+            average_entry_price=Decimal("3100"), current_price=Decimal("2750"),
+            total_cost=Decimal("1000"), total_volume=Decimal("0.32"),
+            safety_orders_filled=0, max_safety_orders=5,
+        )
+        result = manager.check_deal_stop_loss(deal)
+        assert result.action == DCARiskAction.CLOSE_DEAL
+        # 350/3100 = 11.3% > 10%
+
+    def test_stop_loss_warning(self, manager):
+        deal = DealRiskState(
+            deal_id="D1", symbol="BTC", entry_price=Decimal("3100"),
+            average_entry_price=Decimal("3100"), current_price=Decimal("2880"),
+            total_cost=Decimal("1000"), total_volume=Decimal("0.32"),
+            safety_orders_filled=0, max_safety_orders=5,
+        )
+        result = manager.check_deal_stop_loss(deal)
+        assert result.is_safe
+        assert len(result.warnings) > 0  # ~7.1% >= 7% (70% of 10%)
+
+    def test_stop_loss_from_average(self):
+        cfg = DCARiskConfig(deal_stop_loss_from_average=True, deal_stop_loss_pct=Decimal("10.0"))
+        mgr = DCARiskManager(cfg)
+        deal = DealRiskState(
+            deal_id="D1", symbol="BTC", entry_price=Decimal("3100"),
+            average_entry_price=Decimal("3000"), current_price=Decimal("2680"),
+            total_cost=Decimal("1000"), total_volume=Decimal("0.33"),
+            safety_orders_filled=1, max_safety_orders=5,
+        )
+        result = mgr.check_deal_stop_loss(deal)
+        # (3000-2680)/3000 = 10.7% > 10% — triggered
+        assert result.action == DCARiskAction.CLOSE_DEAL
+
+
+# =========================================================================
+# Deal Drawdown Tests
+# =========================================================================
+
+
+class TestDealDrawdown:
+    def test_no_drawdown(self, manager):
+        deal = DealRiskState(
+            deal_id="D1", symbol="BTC", entry_price=Decimal("3100"),
+            average_entry_price=Decimal("3100"), current_price=Decimal("3200"),
+            total_cost=Decimal("1000"), total_volume=Decimal("0.32"),
+            safety_orders_filled=0, max_safety_orders=5,
+            unrealized_pnl=Decimal("32"), unrealized_pnl_pct=Decimal("3.2"),
+        )
+        result = manager.check_deal_drawdown(deal)
+        assert result.is_safe
+
+    def test_drawdown_exceeded(self, manager):
+        deal = DealRiskState(
+            deal_id="D1", symbol="BTC", entry_price=Decimal("3100"),
+            average_entry_price=Decimal("3100"), current_price=Decimal("2600"),
+            total_cost=Decimal("1000"), total_volume=Decimal("0.32"),
+            safety_orders_filled=0, max_safety_orders=5,
+            unrealized_pnl=Decimal("-160"), unrealized_pnl_pct=Decimal("-16.0"),
+        )
+        result = manager.check_deal_drawdown(deal)
+        assert result.action == DCARiskAction.CLOSE_DEAL
+
+    def test_drawdown_warning(self, manager):
+        deal = DealRiskState(
+            deal_id="D1", symbol="BTC", entry_price=Decimal("3100"),
+            average_entry_price=Decimal("3100"), current_price=Decimal("2750"),
+            total_cost=Decimal("1000"), total_volume=Decimal("0.32"),
+            safety_orders_filled=0, max_safety_orders=5,
+            unrealized_pnl=Decimal("-112"), unrealized_pnl_pct=Decimal("-11.2"),
+        )
+        result = manager.check_deal_drawdown(deal)
+        assert result.is_safe
+        assert len(result.warnings) > 0  # 11.2% >= 10.5% (70% of 15%)
+
+
+# =========================================================================
+# Concurrent Deals Tests
+# =========================================================================
+
+
+class TestConcurrentDeals:
+    def test_within_limit(self, manager):
+        result = manager.check_concurrent_deals(1)
+        assert result.is_safe
+
+    def test_at_limit(self, manager):
+        result = manager.check_concurrent_deals(3)
+        assert result.action == DCARiskAction.PAUSE
+
+    def test_over_limit(self, manager):
+        result = manager.check_concurrent_deals(5)
+        assert result.action == DCARiskAction.PAUSE
+
+    def test_approaching_limit(self, manager):
+        result = manager.check_concurrent_deals(2)
+        assert result.is_safe
+        assert len(result.warnings) > 0
+
+
+# =========================================================================
+# Portfolio Drawdown Tests
+# =========================================================================
+
+
+class TestPortfolioDrawdown:
+    def test_no_drawdown(self, manager):
+        result = manager.check_portfolio_drawdown(Decimal("10000"))
+        assert result.is_safe
+        assert manager._peak_equity == Decimal("10000")
+
+    def test_new_peak(self, manager):
+        manager.check_portfolio_drawdown(Decimal("10000"))
+        manager.check_portfolio_drawdown(Decimal("11000"))
+        assert manager._peak_equity == Decimal("11000")
+
+    def test_drawdown_exceeded(self, manager):
+        manager.check_portfolio_drawdown(Decimal("10000"))
+        result = manager.check_portfolio_drawdown(Decimal("8900"))
+        # 11% > 10%
+        assert result.action == DCARiskAction.CLOSE_ALL
+
+    def test_drawdown_warning(self, manager):
+        manager.check_portfolio_drawdown(Decimal("10000"))
+        result = manager.check_portfolio_drawdown(Decimal("9250"))
+        # 7.5% >= 7% (70% of 10%)
+        assert result.is_safe
+        assert len(result.warnings) > 0
+
+    def test_zero_peak(self, manager):
+        result = manager.check_portfolio_drawdown(Decimal("0"))
+        assert result.is_safe
+
+
+# =========================================================================
+# Daily Loss Tests
+# =========================================================================
+
+
+class TestDailyLoss:
+    def test_within_limit(self, manager):
+        result = manager.check_daily_loss(Decimal("-300"))
+        assert result.is_safe
+
+    def test_exceeded(self, manager):
+        result = manager.check_daily_loss(Decimal("-600"))
+        assert result.action == DCARiskAction.PAUSE
+
+    def test_warning(self, manager):
+        result = manager.check_daily_loss(Decimal("-380"))
+        assert result.is_safe
+        assert len(result.warnings) > 0  # -380 < -350 (70% of 500)
+
+    def test_uses_internal_tracking(self, manager):
+        manager.record_trade_result(Decimal("-300"))
+        manager.record_trade_result(Decimal("-250"))
+        result = manager.check_daily_loss()
+        assert result.action == DCARiskAction.PAUSE
+
+
+# =========================================================================
+# Consecutive Loss Tests
+# =========================================================================
+
+
+class TestConsecutiveLosses:
+    def test_no_losses(self, manager):
+        result = manager.check_consecutive_losses()
+        assert result.is_safe
+
+    def test_under_limit(self, manager):
+        for _ in range(4):
+            manager.record_trade_result(Decimal("-10"))
+        result = manager.check_consecutive_losses()
+        assert result.is_safe
+
+    def test_at_limit(self, manager):
+        for _ in range(5):
+            manager.record_trade_result(Decimal("-10"))
+        result = manager.check_consecutive_losses()
+        assert result.action == DCARiskAction.PAUSE
+
+    def test_win_resets(self, manager):
+        for _ in range(3):
+            manager.record_trade_result(Decimal("-10"))
+        manager.record_trade_result(Decimal("50"))
+        assert manager._consecutive_losses == 0
+
+
+# =========================================================================
+# Balance Protection Tests
+# =========================================================================
+
+
+class TestBalanceProtection:
+    def test_sufficient(self, manager):
+        result = manager.check_balance(Decimal("3000"), Decimal("10000"))
+        assert result.is_safe
+
+    def test_insufficient(self, manager):
+        result = manager.check_balance(Decimal("1500"), Decimal("10000"))
+        assert result.action == DCARiskAction.PAUSE
+
+    def test_zero_balance(self, manager):
+        result = manager.check_balance(Decimal("0"), Decimal("0"))
+        assert result.action == DCARiskAction.PAUSE
+
+
+# =========================================================================
+# Total Exposure Tests
+# =========================================================================
+
+
+class TestTotalExposure:
+    def test_within_limit(self, manager, safe_deal):
+        result = manager.check_total_exposure([safe_deal])
+        assert result.is_safe
+
+    def test_exceeded(self, manager):
+        deals = [
+            DealRiskState(
+                deal_id=f"D{i}", symbol="BTC",
+                entry_price=Decimal("3100"), average_entry_price=Decimal("3100"),
+                current_price=Decimal("3000"), total_cost=Decimal("6000"),
+                total_volume=Decimal("2.0"), safety_orders_filled=0,
+                max_safety_orders=5,
+            )
+            for i in range(3)
+        ]
+        result = manager.check_total_exposure(deals)
+        # 6000 * 3 = 18000 > 15000
+        assert result.action == DCARiskAction.PAUSE
+
+    def test_warning(self, manager):
+        deals = [
+            DealRiskState(
+                deal_id="D1", symbol="BTC",
+                entry_price=Decimal("3100"), average_entry_price=Decimal("3100"),
+                current_price=Decimal("3000"), total_cost=Decimal("13000"),
+                total_volume=Decimal("4.0"), safety_orders_filled=0,
+                max_safety_orders=5,
+            )
+        ]
+        result = manager.check_total_exposure(deals)
+        # 13000 > 12750 (85% of 15000)
+        assert result.is_safe
+        assert len(result.warnings) > 0
+
+
+# =========================================================================
+# Price Change (Pump & Dump) Tests
+# =========================================================================
+
+
+class TestPriceChange:
+    def test_normal_change(self, manager):
+        result = manager.check_price_change(Decimal("3100"), Decimal("3200"))
+        assert result.is_safe
+
+    def test_extreme_increase(self, manager):
+        result = manager.check_price_change(Decimal("3100"), Decimal("3500"))
+        # 12.9% > 10%
+        assert result.action == DCARiskAction.PAUSE
+
+    def test_extreme_decrease(self, manager):
+        result = manager.check_price_change(Decimal("3100"), Decimal("2700"))
+        # 12.9% > 10%
+        assert result.action == DCARiskAction.PAUSE
+
+    def test_no_pause_on_volatility_disabled(self):
+        cfg = DCARiskConfig(pause_on_extreme_volatility=False)
+        mgr = DCARiskManager(cfg)
+        result = mgr.check_price_change(Decimal("3100"), Decimal("3500"))
+        assert result.is_safe  # Warning only
+        assert len(result.warnings) > 0
+
+    def test_zero_previous_price(self, manager):
+        result = manager.check_price_change(Decimal("0"), Decimal("3100"))
+        assert result.is_safe
+
+
+# =========================================================================
+# Can Open New Deal Tests
+# =========================================================================
+
+
+class TestCanOpenNewDeal:
+    def test_can_open(self, manager):
+        result = manager.can_open_new_deal(
+            active_deal_count=1,
+            deal_cost=Decimal("1000"),
+            current_exposure=Decimal("5000"),
+            available_balance=Decimal("5000"),
+            total_balance=Decimal("10000"),
+        )
+        assert result.is_safe
+
+    def test_blocked_by_deals(self, manager):
+        result = manager.can_open_new_deal(
+            active_deal_count=3,
+            deal_cost=Decimal("1000"),
+            current_exposure=Decimal("5000"),
+            available_balance=Decimal("5000"),
+            total_balance=Decimal("10000"),
+        )
+        assert not result.is_safe
+        assert "concurrent" in result.reasons[0].lower()
+
+    def test_blocked_by_exposure(self, manager):
+        result = manager.can_open_new_deal(
+            active_deal_count=1,
+            deal_cost=Decimal("1000"),
+            current_exposure=Decimal("14500"),
+            available_balance=Decimal("5000"),
+            total_balance=Decimal("10000"),
+        )
+        assert not result.is_safe
+        assert "exposure" in result.reasons[0].lower()
+
+    def test_blocked_by_deal_cost(self, manager):
+        result = manager.can_open_new_deal(
+            active_deal_count=1,
+            deal_cost=Decimal("6000"),
+            current_exposure=Decimal("5000"),
+            available_balance=Decimal("7000"),
+            total_balance=Decimal("10000"),
+        )
+        assert not result.is_safe
+        assert "cost exceeds" in result.reasons[0].lower()
+
+    def test_blocked_by_balance(self, manager):
+        result = manager.can_open_new_deal(
+            active_deal_count=1,
+            deal_cost=Decimal("4500"),
+            current_exposure=Decimal("5000"),
+            available_balance=Decimal("5000"),
+            total_balance=Decimal("10000"),
+        )
+        assert not result.is_safe
+        assert "balance" in result.reasons[0].lower()
+
+    def test_blocked_by_daily_loss(self, manager):
+        for _ in range(3):
+            manager.record_trade_result(Decimal("-200"))
+        result = manager.can_open_new_deal(
+            active_deal_count=0,
+            deal_cost=Decimal("100"),
+            current_exposure=Decimal("0"),
+            available_balance=Decimal("5000"),
+            total_balance=Decimal("10000"),
+        )
+        assert not result.is_safe
+
+    def test_blocked_by_consecutive_losses(self, manager):
+        for _ in range(5):
+            manager.record_trade_result(Decimal("-10"))
+        result = manager.can_open_new_deal(
+            active_deal_count=0,
+            deal_cost=Decimal("100"),
+            current_exposure=Decimal("0"),
+            available_balance=Decimal("5000"),
+            total_balance=Decimal("10000"),
+        )
+        assert not result.is_safe
+
+
+# =========================================================================
+# Full Risk Evaluation Tests
+# =========================================================================
+
+
+class TestEvaluateRisk:
+    def test_all_safe(self, manager, safe_portfolio):
+        manager.check_portfolio_drawdown(Decimal("10000"))  # set peak
+        result = manager.evaluate_risk(safe_portfolio)
+        assert result.is_safe
+
+    def test_deal_stop_loss_triggers(self, manager):
+        deal = DealRiskState(
+            deal_id="D1", symbol="BTC", entry_price=Decimal("3100"),
+            average_entry_price=Decimal("3100"), current_price=Decimal("2700"),
+            total_cost=Decimal("1000"), total_volume=Decimal("0.32"),
+            safety_orders_filled=0, max_safety_orders=5,
+            unrealized_pnl=Decimal("-128"), unrealized_pnl_pct=Decimal("-12.9"),
+        )
+        state = PortfolioRiskState(
+            active_deals=[deal],
+            total_equity=Decimal("10000"),
+            available_balance=Decimal("5000"),
+            total_balance=Decimal("10000"),
+        )
+        manager.check_portfolio_drawdown(Decimal("10000"))
+        result = manager.evaluate_risk(state)
+        assert result.action == DCARiskAction.CLOSE_DEAL
+
+    def test_portfolio_drawdown_overrides(self, manager):
+        deal = DealRiskState(
+            deal_id="D1", symbol="BTC", entry_price=Decimal("3100"),
+            average_entry_price=Decimal("3100"), current_price=Decimal("3000"),
+            total_cost=Decimal("1000"), total_volume=Decimal("0.32"),
+            safety_orders_filled=0, max_safety_orders=5,
+        )
+        state = PortfolioRiskState(
+            active_deals=[deal],
+            total_equity=Decimal("8800"),  # 12% drop from peak 10000
+            available_balance=Decimal("5000"),
+            total_balance=Decimal("10000"),
+        )
+        manager.check_portfolio_drawdown(Decimal("10000"))
+        result = manager.evaluate_risk(state)
+        assert result.action == DCARiskAction.CLOSE_ALL
+
+    def test_warnings_collected(self, manager):
+        deal = DealRiskState(
+            deal_id="D1", symbol="BTC", entry_price=Decimal("3100"),
+            average_entry_price=Decimal("3100"), current_price=Decimal("2880"),
+            total_cost=Decimal("1000"), total_volume=Decimal("0.32"),
+            safety_orders_filled=0, max_safety_orders=5,
+            unrealized_pnl=Decimal("-70"), unrealized_pnl_pct=Decimal("-7.1"),
+        )
+        state = PortfolioRiskState(
+            active_deals=[deal],
+            total_equity=Decimal("10000"),
+            available_balance=Decimal("5000"),
+            total_balance=Decimal("10000"),
+        )
+        manager.check_portfolio_drawdown(Decimal("10000"))
+        result = manager.evaluate_risk(state)
+        assert result.is_safe
+        # Should have deal SL warning (~7.1% >= 7% threshold)
+        assert len(result.warnings) > 0
+
+
+# =========================================================================
+# State Management Tests
+# =========================================================================
+
+
+class TestStateManagement:
+    def test_record_trade_result(self, manager):
+        manager.record_trade_result(Decimal("100"))
+        assert manager._total_realized_pnl == Decimal("100")
+        assert manager._consecutive_losses == 0
+
+    def test_record_loss(self, manager):
+        manager.record_trade_result(Decimal("-50"))
+        assert manager._consecutive_losses == 1
+        assert manager._daily_realized_pnl == Decimal("-50")
+
+    def test_reset_daily_pnl(self, manager):
+        manager.record_trade_result(Decimal("-200"))
+        manager.reset_daily_pnl()
+        assert manager._daily_realized_pnl == Decimal("0")
+        assert manager._total_realized_pnl == Decimal("-200")  # Total unchanged
+
+    def test_full_reset(self, manager):
+        manager.record_trade_result(Decimal("-200"))
+        manager.check_portfolio_drawdown(Decimal("10000"))
+        manager.reset()
+        assert manager._peak_equity == Decimal("0")
+        assert manager._consecutive_losses == 0
+        assert manager._total_realized_pnl == Decimal("0")
+        assert manager._daily_realized_pnl == Decimal("0")
+
+    def test_statistics(self, manager):
+        manager.record_trade_result(Decimal("-50"))
+        stats = manager.get_statistics()
+        assert stats["consecutive_losses"] == 1
+        assert stats["total_realized_pnl"] == "-50"
+        assert stats["config"]["max_concurrent_deals"] == 3
+
+    def test_default_manager(self):
+        mgr = DCARiskManager()
+        assert mgr.config.max_concurrent_deals == 3


### PR DESCRIPTION
## Summary
- Created `bot/strategies/dca/dca_risk_manager.py` — comprehensive DCA risk control
- Per-deal stop-loss (from base or average entry price)
- Per-deal and portfolio-level drawdown tracking with peak equity
- Concurrent deal limits, daily loss limits, consecutive loss streaks
- Balance protection (min free balance percentage)
- Total exposure monitoring across all deals
- Pump & dump protection via extreme price change detection
- `can_open_new_deal()` convenience method combining all pre-open checks
- Priority-based action system: CLOSE_ALL > CLOSE_DEAL > REDUCE > PAUSE > CONTINUE
- 66 unit tests

## Test plan
- [x] Config validation (11 tests)
- [x] Deal stop-loss (4 tests)
- [x] Deal drawdown (3 tests)
- [x] Concurrent deals (4 tests)
- [x] Portfolio drawdown (5 tests)
- [x] Daily loss (4 tests)
- [x] Consecutive losses (4 tests)
- [x] Balance protection (3 tests)
- [x] Total exposure (3 tests)
- [x] Price change / pump & dump (5 tests)
- [x] Can open new deal (7 tests)
- [x] Full evaluation (4 tests)
- [x] State management (6 tests)

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)