### PR TITLE
feat: DCA Trailing Stop with dynamic stop price (#162)

### DIFF
--- a/bot/strategies/dca/__init__.py
+++ b/bot/strategies/dca/__init__.py
@@ -1,4 +1,4 @@
-"""DCA Strategy Package — v2.0 Signal Generator, Position Manager, Risk Manager."""
+"""DCA Strategy Package — v2.0 Signal Generator, Position Manager, Risk Manager, Trailing Stop."""
 
 from bot.strategies.dca.dca_signal_generator import (
     ConditionResult,
@@ -26,6 +26,14 @@ from bot.strategies.dca.dca_risk_manager import (
     PortfolioRiskState,
     RiskCheckResult,
 )
+from bot.strategies.dca.dca_trailing_stop import (
+    DCATrailingStop,
+    TrailingStopConfig,
+    TrailingStopResult,
+    TrailingStopSnapshot,
+    TrailingStopState,
+    TrailingStopType,
+)
 
 __all__ = [
     "DCASignalGenerator",
@@ -48,4 +56,10 @@ __all__ = [
     "RiskCheckResult",
     "DealRiskState",
     "PortfolioRiskState",
+    "DCATrailingStop",
+    "TrailingStopConfig",
+    "TrailingStopResult",
+    "TrailingStopSnapshot",
+    "TrailingStopState",
+    "TrailingStopType",
 ]

--- a/bot/strategies/dca/dca_trailing_stop.py
+++ b/bot/strategies/dca/dca_trailing_stop.py
@@ -1,0 +1,328 @@
+"""
+DCA Trailing Stop — v2.0.
+
+Dynamic trailing stop-loss that follows price highs to protect profit:
+- Tracks highest_price_since_entry (never reset on safety orders)
+- Activates only after minimum profit threshold is reached
+- Calculates stop price as percentage or absolute distance from highest
+- Programmatic execution (not exchange-level orders)
+
+Key principle: The trailing stop highest price is NEVER reset when
+safety orders fill, preserving accumulated profit protection.
+
+Usage:
+    config = TrailingStopConfig(activation_pct=Decimal("1.5"), ...)
+    ts = DCATrailingStop(config)
+    result = ts.evaluate(
+        current_price=Decimal("3500"),
+        average_entry=Decimal("3200"),
+        highest_price=Decimal("3500"),
+    )
+    if result.should_exit:
+        # Close position at market
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
+
+# =============================================================================
+# Enums
+# =============================================================================
+
+
+class TrailingStopType(str, Enum):
+    """Type of trailing stop distance calculation."""
+
+    PERCENTAGE = "percentage"  # Stop at highest * (1 - distance/100)
+    ABSOLUTE = "absolute"  # Stop at highest - distance
+
+
+class TrailingStopState(str, Enum):
+    """Current state of the trailing stop."""
+
+    INACTIVE = "inactive"  # Profit below activation threshold
+    ACTIVE = "active"  # Trailing is active, tracking highest
+    TRIGGERED = "triggered"  # Stop price hit, exit signal
+
+
+# =============================================================================
+# Data Structures
+# =============================================================================
+
+
+@dataclass
+class TrailingStopResult:
+    """Result of a trailing stop evaluation."""
+
+    state: TrailingStopState
+    should_exit: bool
+    stop_price: Decimal | None = None
+    current_profit_pct: Decimal = Decimal("0")
+    highest_price: Decimal = Decimal("0")
+    distance_to_stop_pct: Decimal | None = None
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "state": self.state.value,
+            "should_exit": self.should_exit,
+            "stop_price": str(self.stop_price) if self.stop_price else None,
+            "current_profit_pct": str(self.current_profit_pct),
+            "highest_price": str(self.highest_price),
+            "distance_to_stop_pct": (
+                str(self.distance_to_stop_pct) if self.distance_to_stop_pct else None
+            ),
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class TrailingStopSnapshot:
+    """
+    Persistent state for a deal's trailing stop.
+
+    Store this in the deal record for persistence across restarts.
+    """
+
+    highest_price_since_entry: Decimal = Decimal("0")
+    is_activated: bool = False
+    activation_price: Decimal | None = None
+    activation_time: datetime | None = None
+    last_stop_price: Decimal | None = None
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+
+@dataclass
+class TrailingStopConfig:
+    """
+    Trailing stop configuration.
+
+    Attributes:
+        enabled: Whether trailing stop is active.
+        activation_pct: Minimum profit % to activate trailing.
+        distance_pct: Distance from highest for percentage type.
+        distance_abs: Distance from highest for absolute type.
+        stop_type: Percentage or absolute calculation.
+    """
+
+    enabled: bool = True
+    activation_pct: Decimal = Decimal("1.5")  # Activate at 1.5% profit
+    distance_pct: Decimal = Decimal("0.8")  # 0.8% from highest
+    distance_abs: Decimal = Decimal("25")  # $25 from highest (for absolute type)
+    stop_type: TrailingStopType = TrailingStopType.PERCENTAGE
+
+    def validate(self) -> None:
+        """Validate configuration."""
+        if self.activation_pct < 0:
+            raise ValueError("activation_pct must be >= 0")
+        if self.distance_pct <= 0:
+            raise ValueError("distance_pct must be positive")
+        if self.distance_abs <= 0:
+            raise ValueError("distance_abs must be positive")
+
+    def get_distance(self) -> Decimal:
+        """Get the configured distance based on stop type."""
+        if self.stop_type == TrailingStopType.PERCENTAGE:
+            return self.distance_pct
+        return self.distance_abs
+
+
+# =============================================================================
+# DCA Trailing Stop
+# =============================================================================
+
+
+class DCATrailingStop:
+    """
+    Programmatic trailing stop for DCA deals.
+
+    Evaluates current market price against the highest price since entry
+    to determine whether to exit the position.
+
+    The trailing stop lifecycle:
+    1. INACTIVE: Profit is below activation threshold
+    2. ACTIVE: Profit exceeded threshold, tracking highest price
+    3. TRIGGERED: Price dropped below stop price, exit signal
+
+    Important behaviors:
+    - highest_price is NEVER reset on safety order fills
+    - Stop price calculation is dynamic (recalculated each evaluation)
+    - Both percentage and absolute distance modes are supported
+    """
+
+    def __init__(self, config: TrailingStopConfig | None = None):
+        self._config = config or TrailingStopConfig()
+        if self._config.enabled:
+            self._config.validate()
+
+    @property
+    def config(self) -> TrailingStopConfig:
+        return self._config
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    # -----------------------------------------------------------------
+    # Core Evaluation
+    # -----------------------------------------------------------------
+
+    def evaluate(
+        self,
+        current_price: Decimal,
+        average_entry: Decimal,
+        highest_price: Decimal,
+        snapshot: TrailingStopSnapshot | None = None,
+    ) -> TrailingStopResult:
+        """
+        Evaluate trailing stop condition.
+
+        Args:
+            current_price: Current market price.
+            average_entry: Current average entry price (after all SOs).
+            highest_price: Highest price since entry (caller must track).
+            snapshot: Optional persistent state for activation tracking.
+
+        Returns:
+            TrailingStopResult with exit decision.
+        """
+        if not self._config.enabled:
+            return TrailingStopResult(
+                state=TrailingStopState.INACTIVE,
+                should_exit=False,
+                reason="Trailing stop disabled",
+            )
+
+        if average_entry <= 0:
+            return TrailingStopResult(
+                state=TrailingStopState.INACTIVE,
+                should_exit=False,
+                reason="Invalid average entry",
+            )
+
+        # Update highest price
+        new_highest = max(highest_price, current_price)
+
+        # Calculate current profit
+        profit_pct = ((current_price - average_entry) / average_entry) * 100
+
+        # Check activation
+        if profit_pct < self._config.activation_pct:
+            return TrailingStopResult(
+                state=TrailingStopState.INACTIVE,
+                should_exit=False,
+                current_profit_pct=profit_pct,
+                highest_price=new_highest,
+                reason=(
+                    f"Profit {profit_pct:.2f}% below activation "
+                    f"({self._config.activation_pct}%)"
+                ),
+            )
+
+        # Trailing is active — calculate stop price
+        stop_price = self.calculate_stop_price(new_highest)
+
+        # Update snapshot if provided
+        if snapshot is not None and not snapshot.is_activated:
+            snapshot.is_activated = True
+            snapshot.activation_price = current_price
+            snapshot.activation_time = datetime.now(timezone.utc)
+        if snapshot is not None:
+            snapshot.highest_price_since_entry = new_highest
+            snapshot.last_stop_price = stop_price
+
+        # Check if stop is triggered
+        if current_price <= stop_price:
+            return TrailingStopResult(
+                state=TrailingStopState.TRIGGERED,
+                should_exit=True,
+                stop_price=stop_price,
+                current_profit_pct=profit_pct,
+                highest_price=new_highest,
+                distance_to_stop_pct=Decimal("0"),
+                reason=(
+                    f"Trailing stop triggered: price {current_price} "
+                    f"<= stop {stop_price} (highest: {new_highest})"
+                ),
+            )
+
+        # Active but not triggered
+        distance_to_stop = (
+            ((current_price - stop_price) / current_price) * 100
+            if current_price > 0
+            else Decimal("0")
+        )
+
+        return TrailingStopResult(
+            state=TrailingStopState.ACTIVE,
+            should_exit=False,
+            stop_price=stop_price,
+            current_profit_pct=profit_pct,
+            highest_price=new_highest,
+            distance_to_stop_pct=distance_to_stop,
+            reason=(
+                f"Trailing active: stop={stop_price}, "
+                f"distance={distance_to_stop:.2f}%"
+            ),
+        )
+
+    # -----------------------------------------------------------------
+    # Stop Price Calculation
+    # -----------------------------------------------------------------
+
+    def calculate_stop_price(self, highest_price: Decimal) -> Decimal:
+        """
+        Calculate the current stop price based on highest price.
+
+        For PERCENTAGE type: highest * (1 - distance/100)
+        For ABSOLUTE type: highest - distance
+        """
+        cfg = self._config
+
+        if cfg.stop_type == TrailingStopType.PERCENTAGE:
+            return highest_price * (1 - cfg.distance_pct / 100)
+        else:
+            return highest_price - cfg.distance_abs
+
+    # -----------------------------------------------------------------
+    # Utilities
+    # -----------------------------------------------------------------
+
+    def update_highest(
+        self, current_highest: Decimal, current_price: Decimal
+    ) -> tuple[Decimal, bool]:
+        """
+        Update highest price. Returns (new_highest, was_updated).
+
+        This should be called on every price update. The highest
+        is NEVER reduced, only increased.
+        """
+        if current_price > current_highest:
+            return current_price, True
+        return current_highest, False
+
+    def get_activation_price(self, average_entry: Decimal) -> Decimal:
+        """Calculate the price at which trailing stop activates."""
+        return average_entry * (1 + self._config.activation_pct / 100)
+
+    def get_statistics(self) -> dict[str, Any]:
+        """Return config summary."""
+        cfg = self._config
+        return {
+            "enabled": cfg.enabled,
+            "stop_type": cfg.stop_type.value,
+            "activation_pct": str(cfg.activation_pct),
+            "distance": (
+                str(cfg.distance_pct) + "%"
+                if cfg.stop_type == TrailingStopType.PERCENTAGE
+                else str(cfg.distance_abs)
+            ),
+        }

--- a/tests/strategies/dca/test_dca_trailing_stop.py
+++ b/tests/strategies/dca/test_dca_trailing_stop.py
@@ -1,0 +1,516 @@
+"""Tests for DCA Trailing Stop v2.0.
+
+Tests highest price tracking, activation, stop price calculation,
+trigger detection, snapshot persistence, and full lifecycle.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from bot.strategies.dca.dca_trailing_stop import (
+    DCATrailingStop,
+    TrailingStopConfig,
+    TrailingStopResult,
+    TrailingStopSnapshot,
+    TrailingStopState,
+    TrailingStopType,
+)
+
+
+# =========================================================================
+# Fixtures
+# =========================================================================
+
+
+@pytest.fixture
+def pct_config():
+    return TrailingStopConfig(
+        enabled=True,
+        activation_pct=Decimal("1.5"),
+        distance_pct=Decimal("0.8"),
+        stop_type=TrailingStopType.PERCENTAGE,
+    )
+
+
+@pytest.fixture
+def abs_config():
+    return TrailingStopConfig(
+        enabled=True,
+        activation_pct=Decimal("1.5"),
+        distance_abs=Decimal("25"),
+        stop_type=TrailingStopType.ABSOLUTE,
+    )
+
+
+@pytest.fixture
+def ts_pct(pct_config):
+    return DCATrailingStop(pct_config)
+
+
+@pytest.fixture
+def ts_abs(abs_config):
+    return DCATrailingStop(abs_config)
+
+
+# =========================================================================
+# Config Validation Tests
+# =========================================================================
+
+
+class TestTrailingStopConfig:
+    def test_defaults(self):
+        cfg = TrailingStopConfig()
+        cfg.validate()
+
+    def test_invalid_activation(self):
+        cfg = TrailingStopConfig(activation_pct=Decimal("-1"))
+        with pytest.raises(ValueError, match="activation_pct"):
+            cfg.validate()
+
+    def test_invalid_distance_pct(self):
+        cfg = TrailingStopConfig(distance_pct=Decimal("0"))
+        with pytest.raises(ValueError, match="distance_pct"):
+            cfg.validate()
+
+    def test_invalid_distance_abs(self):
+        cfg = TrailingStopConfig(distance_abs=Decimal("-5"))
+        with pytest.raises(ValueError, match="distance_abs"):
+            cfg.validate()
+
+    def test_get_distance_percentage(self, pct_config):
+        assert pct_config.get_distance() == Decimal("0.8")
+
+    def test_get_distance_absolute(self, abs_config):
+        assert abs_config.get_distance() == Decimal("25")
+
+
+# =========================================================================
+# Stop Price Calculation Tests
+# =========================================================================
+
+
+class TestStopPriceCalculation:
+    def test_percentage_stop(self, ts_pct):
+        # highest=3500, distance=0.8% → 3500 * (1 - 0.008) = 3472
+        stop = ts_pct.calculate_stop_price(Decimal("3500"))
+        assert stop == Decimal("3472.00")
+
+    def test_absolute_stop(self, ts_abs):
+        # highest=3500, distance=25 → 3500 - 25 = 3475
+        stop = ts_abs.calculate_stop_price(Decimal("3500"))
+        assert stop == Decimal("3475")
+
+    def test_stop_rises_with_highest(self, ts_pct):
+        stop1 = ts_pct.calculate_stop_price(Decimal("3400"))
+        stop2 = ts_pct.calculate_stop_price(Decimal("3500"))
+        assert stop2 > stop1
+
+    def test_small_price_percentage(self, ts_pct):
+        stop = ts_pct.calculate_stop_price(Decimal("1.00"))
+        assert stop == Decimal("0.99200")
+
+
+# =========================================================================
+# Activation Tests
+# =========================================================================
+
+
+class TestActivation:
+    def test_inactive_below_threshold(self, ts_pct):
+        result = ts_pct.evaluate(
+            current_price=Decimal("3140"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3140"),
+        )
+        # 40/3100 = 1.29% < 1.5%
+        assert result.state == TrailingStopState.INACTIVE
+        assert result.should_exit is False
+
+    def test_activates_above_threshold(self, ts_pct):
+        result = ts_pct.evaluate(
+            current_price=Decimal("3150"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3150"),
+        )
+        # 50/3100 = 1.61% > 1.5%
+        assert result.state == TrailingStopState.ACTIVE
+        assert result.should_exit is False
+
+    def test_activation_exact_threshold(self, ts_pct):
+        # 1.5% of 3100 = 46.5 → activation at 3146.5
+        result = ts_pct.evaluate(
+            current_price=Decimal("3146.50"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3146.50"),
+        )
+        assert result.state == TrailingStopState.ACTIVE
+
+    def test_get_activation_price(self, ts_pct):
+        price = ts_pct.get_activation_price(Decimal("3100"))
+        assert price == Decimal("3146.500")
+
+    def test_disabled_always_inactive(self):
+        cfg = TrailingStopConfig(enabled=False)
+        ts = DCATrailingStop(cfg)
+        result = ts.evaluate(
+            current_price=Decimal("5000"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("5000"),
+        )
+        assert result.state == TrailingStopState.INACTIVE
+        assert result.should_exit is False
+
+
+# =========================================================================
+# Trigger Tests
+# =========================================================================
+
+
+class TestTrigger:
+    def test_triggered_on_drop(self, ts_pct):
+        # highest=3500, stop=3472, current=3470 → triggered
+        result = ts_pct.evaluate(
+            current_price=Decimal("3470"),
+            average_entry=Decimal("3200"),
+            highest_price=Decimal("3500"),
+        )
+        assert result.state == TrailingStopState.TRIGGERED
+        assert result.should_exit is True
+        assert result.stop_price == Decimal("3472.00")
+
+    def test_not_triggered_above_stop(self, ts_pct):
+        # highest=3500, stop=3472, current=3480 → active (not triggered)
+        result = ts_pct.evaluate(
+            current_price=Decimal("3480"),
+            average_entry=Decimal("3200"),
+            highest_price=Decimal("3500"),
+        )
+        assert result.state == TrailingStopState.ACTIVE
+        assert result.should_exit is False
+
+    def test_triggered_at_exact_stop(self, ts_pct):
+        # exactly at stop price
+        result = ts_pct.evaluate(
+            current_price=Decimal("3472.00"),
+            average_entry=Decimal("3200"),
+            highest_price=Decimal("3500"),
+        )
+        assert result.state == TrailingStopState.TRIGGERED
+        assert result.should_exit is True
+
+    def test_triggered_absolute_type(self, ts_abs):
+        # highest=3500, stop=3475, current=3474 → triggered
+        result = ts_abs.evaluate(
+            current_price=Decimal("3474"),
+            average_entry=Decimal("3200"),
+            highest_price=Decimal("3500"),
+        )
+        assert result.state == TrailingStopState.TRIGGERED
+        assert result.should_exit is True
+
+    def test_not_triggered_when_inactive(self, ts_pct):
+        """Even if price drops below would-be stop, don't trigger if not activated."""
+        result = ts_pct.evaluate(
+            current_price=Decimal("3100"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3100"),
+        )
+        assert result.state == TrailingStopState.INACTIVE
+        assert result.should_exit is False
+
+
+# =========================================================================
+# Highest Price Tracking Tests
+# =========================================================================
+
+
+class TestHighestPriceTracking:
+    def test_update_new_high(self, ts_pct):
+        new, updated = ts_pct.update_highest(Decimal("3400"), Decimal("3500"))
+        assert new == Decimal("3500")
+        assert updated is True
+
+    def test_no_update_below(self, ts_pct):
+        new, updated = ts_pct.update_highest(Decimal("3500"), Decimal("3400"))
+        assert new == Decimal("3500")
+        assert updated is False
+
+    def test_no_update_equal(self, ts_pct):
+        new, updated = ts_pct.update_highest(Decimal("3500"), Decimal("3500"))
+        assert new == Decimal("3500")
+        assert updated is False
+
+    def test_highest_in_result(self, ts_pct):
+        result = ts_pct.evaluate(
+            current_price=Decimal("3200"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3300"),
+        )
+        # current_price > highest_price is not the case here
+        # highest stays at 3300
+        assert result.highest_price == Decimal("3300")
+
+    def test_highest_updated_in_result(self, ts_pct):
+        result = ts_pct.evaluate(
+            current_price=Decimal("3400"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3300"),
+        )
+        # current_price > highest → highest updated to 3400
+        assert result.highest_price == Decimal("3400")
+
+    def test_highest_not_reset_concept(self, ts_pct):
+        """
+        Demonstrate that highest is passed in, not stored internally.
+        The caller (DCAPositionManager) is responsible for NOT resetting
+        highest_price on safety order fills.
+        """
+        # First eval: highest=3400
+        r1 = ts_pct.evaluate(
+            current_price=Decimal("3200"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3400"),
+        )
+        assert r1.highest_price == Decimal("3400")
+
+        # Simulate safety order fill at 3050 — caller keeps highest=3400
+        r2 = ts_pct.evaluate(
+            current_price=Decimal("3050"),
+            average_entry=Decimal("3075"),  # avg entry dropped
+            highest_price=Decimal("3400"),  # NOT reset!
+        )
+        assert r2.highest_price == Decimal("3400")
+
+
+# =========================================================================
+# Snapshot Persistence Tests
+# =========================================================================
+
+
+class TestSnapshot:
+    def test_snapshot_activation(self, ts_pct):
+        snapshot = TrailingStopSnapshot()
+        assert snapshot.is_activated is False
+
+        ts_pct.evaluate(
+            current_price=Decimal("3200"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3200"),
+            snapshot=snapshot,
+        )
+        assert snapshot.is_activated is True
+        assert snapshot.activation_price == Decimal("3200")
+        assert snapshot.activation_time is not None
+
+    def test_snapshot_not_activated_below_threshold(self, ts_pct):
+        snapshot = TrailingStopSnapshot()
+        ts_pct.evaluate(
+            current_price=Decimal("3140"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3140"),
+            snapshot=snapshot,
+        )
+        assert snapshot.is_activated is False
+
+    def test_snapshot_highest_updated(self, ts_pct):
+        snapshot = TrailingStopSnapshot()
+        ts_pct.evaluate(
+            current_price=Decimal("3200"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3200"),
+            snapshot=snapshot,
+        )
+        assert snapshot.highest_price_since_entry == Decimal("3200")
+
+        ts_pct.evaluate(
+            current_price=Decimal("3300"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3300"),
+            snapshot=snapshot,
+        )
+        assert snapshot.highest_price_since_entry == Decimal("3300")
+
+    def test_snapshot_stop_price_updated(self, ts_pct):
+        snapshot = TrailingStopSnapshot()
+        ts_pct.evaluate(
+            current_price=Decimal("3200"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3200"),
+            snapshot=snapshot,
+        )
+        assert snapshot.last_stop_price is not None
+
+    def test_snapshot_activation_not_reset(self, ts_pct):
+        """Once activated, stays activated even if price drops below threshold."""
+        snapshot = TrailingStopSnapshot()
+        # Activate
+        ts_pct.evaluate(
+            current_price=Decimal("3200"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3200"),
+            snapshot=snapshot,
+        )
+        activation_time = snapshot.activation_time
+        assert snapshot.is_activated is True
+
+        # Price drops but we still pass highest
+        ts_pct.evaluate(
+            current_price=Decimal("3150"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3200"),
+            snapshot=snapshot,
+        )
+        # Activation time should not change
+        assert snapshot.activation_time == activation_time
+
+
+# =========================================================================
+# Edge Cases
+# =========================================================================
+
+
+class TestEdgeCases:
+    def test_zero_average_entry(self, ts_pct):
+        result = ts_pct.evaluate(
+            current_price=Decimal("3200"),
+            average_entry=Decimal("0"),
+            highest_price=Decimal("3200"),
+        )
+        assert result.state == TrailingStopState.INACTIVE
+
+    def test_negative_profit(self, ts_pct):
+        result = ts_pct.evaluate(
+            current_price=Decimal("3000"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3100"),
+        )
+        assert result.state == TrailingStopState.INACTIVE
+
+    def test_large_profit(self, ts_pct):
+        result = ts_pct.evaluate(
+            current_price=Decimal("5000"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("5000"),
+        )
+        assert result.state == TrailingStopState.ACTIVE
+        assert result.current_profit_pct > Decimal("50")
+
+    def test_default_config(self):
+        ts = DCATrailingStop()
+        result = ts.evaluate(
+            current_price=Decimal("3200"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3200"),
+        )
+        assert isinstance(result, TrailingStopResult)
+
+    def test_result_to_dict(self, ts_pct):
+        result = ts_pct.evaluate(
+            current_price=Decimal("3200"),
+            average_entry=Decimal("3100"),
+            highest_price=Decimal("3200"),
+        )
+        d = result.to_dict()
+        assert "state" in d
+        assert "should_exit" in d
+        assert "stop_price" in d
+
+    def test_statistics(self, ts_pct):
+        stats = ts_pct.get_statistics()
+        assert stats["enabled"] is True
+        assert stats["stop_type"] == "percentage"
+        assert stats["activation_pct"] == "1.5"
+
+    def test_enabled_property(self, ts_pct):
+        assert ts_pct.enabled is True
+
+    def test_disabled_property(self):
+        ts = DCATrailingStop(TrailingStopConfig(enabled=False))
+        assert ts.enabled is False
+
+
+# =========================================================================
+# Full Lifecycle Integration Test
+# =========================================================================
+
+
+class TestFullLifecycle:
+    def test_complete_trailing_stop_cycle(self, ts_pct):
+        """
+        Simulate: entry → price rises → activation → new highs →
+        price drops → trailing triggered → exit.
+        """
+        avg_entry = Decimal("3100")
+        snapshot = TrailingStopSnapshot()
+
+        # Step 1: Price barely up — inactive
+        r = ts_pct.evaluate(Decimal("3130"), avg_entry, Decimal("3130"), snapshot)
+        assert r.state == TrailingStopState.INACTIVE
+
+        # Step 2: Price rises past activation (1.5% = 3146.50)
+        r = ts_pct.evaluate(Decimal("3200"), avg_entry, Decimal("3200"), snapshot)
+        assert r.state == TrailingStopState.ACTIVE
+        assert snapshot.is_activated is True
+
+        # Step 3: Price keeps rising
+        r = ts_pct.evaluate(Decimal("3400"), avg_entry, Decimal("3400"), snapshot)
+        assert r.state == TrailingStopState.ACTIVE
+        assert snapshot.highest_price_since_entry == Decimal("3400")
+
+        # Step 4: New all-time high
+        r = ts_pct.evaluate(Decimal("3500"), avg_entry, Decimal("3500"), snapshot)
+        assert r.state == TrailingStopState.ACTIVE
+        assert r.stop_price == Decimal("3472.00")  # 3500 * (1-0.008)
+
+        # Step 5: Price drops but above stop
+        r = ts_pct.evaluate(Decimal("3480"), avg_entry, Decimal("3500"), snapshot)
+        assert r.state == TrailingStopState.ACTIVE
+        assert r.should_exit is False
+
+        # Step 6: Price drops to stop — TRIGGERED
+        r = ts_pct.evaluate(Decimal("3470"), avg_entry, Decimal("3500"), snapshot)
+        assert r.state == TrailingStopState.TRIGGERED
+        assert r.should_exit is True
+        assert r.stop_price == Decimal("3472.00")
+
+    def test_safety_order_does_not_reset_highest(self, ts_pct):
+        """
+        Key behavior: safety order fills at lower price do NOT reset highest.
+        """
+        avg_entry = Decimal("3100")
+        snapshot = TrailingStopSnapshot()
+
+        # Price rises to 3400 — activate trailing
+        ts_pct.evaluate(Decimal("3400"), avg_entry, Decimal("3400"), snapshot)
+        assert snapshot.highest_price_since_entry == Decimal("3400")
+
+        # Safety order fills at 3050 — average entry drops
+        new_avg = Decimal("3075")  # Recalculated after SO
+
+        # Caller keeps highest at 3400 (NOT reset)
+        r = ts_pct.evaluate(Decimal("3050"), new_avg, Decimal("3400"), snapshot)
+        assert snapshot.highest_price_since_entry == Decimal("3400")
+
+        # Price recovers above stop (3400 * 0.992 = 3372.80)
+        r = ts_pct.evaluate(Decimal("3380"), new_avg, Decimal("3400"), snapshot)
+        assert r.state == TrailingStopState.ACTIVE
+        # Stop is still based on 3400 highest
+        assert r.stop_price == Decimal("3372.80")  # 3400 * 0.992
+
+    def test_absolute_trailing_full_cycle(self, ts_abs):
+        """Full cycle with absolute distance ($25)."""
+        avg_entry = Decimal("3100")
+
+        # Activate
+        r = ts_abs.evaluate(Decimal("3200"), avg_entry, Decimal("3200"))
+        assert r.state == TrailingStopState.ACTIVE
+
+        # New high
+        r = ts_abs.evaluate(Decimal("3500"), avg_entry, Decimal("3500"))
+        assert r.stop_price == Decimal("3475")
+
+        # Triggered
+        r = ts_abs.evaluate(Decimal("3474"), avg_entry, Decimal("3500"))
+        assert r.state == TrailingStopState.TRIGGERED
+        assert r.should_exit is True


### PR DESCRIPTION
## Summary
- Created `bot/strategies/dca/dca_trailing_stop.py` — programmatic trailing stop
- Highest price tracking (NEVER reset on safety order fills)
- Activation only after minimum profit % threshold
- Percentage and absolute distance modes for stop price
- TrailingStopSnapshot for persistence across restarts
- Three states: INACTIVE → ACTIVE → TRIGGERED
- 42 unit tests including full lifecycle integration tests

## Test plan
- [x] Config validation (6 tests)
- [x] Stop price calculation (4 tests)
- [x] Activation tests (5 tests)
- [x] Trigger tests (5 tests)
- [x] Highest price tracking (6 tests)
- [x] Snapshot persistence (5 tests)
- [x] Edge cases (8 tests)
- [x] Full lifecycle (3 integration tests)
- [x] Safety order does NOT reset highest price

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)