### PR TITLE
feat: DCA config, backtester & integration tests (#164)

### DIFF
--- a/bot/strategies/dca/__init__.py
+++ b/bot/strategies/dca/__init__.py
@@ -1,4 +1,4 @@
-"""DCA Strategy Package — v2.0 Signal Generator, Position Manager, Risk Manager, Trailing Stop, Engine."""
+"""DCA Strategy Package — v2.0 Signal Generator, Position Manager, Risk Manager, Trailing Stop, Engine, Config, Backtester."""
 
 from bot.strategies.dca.dca_signal_generator import (
     ConditionResult,
@@ -40,6 +40,17 @@ from bot.strategies.dca.dca_engine import (
     EngineAction,
     FalseSignalFilter,
 )
+from bot.strategies.dca.dca_config import (
+    DCAStrategyConfig,
+    MarketPreset,
+    MARKET_PRESETS,
+)
+from bot.strategies.dca.dca_backtester import (
+    BacktestResult,
+    BacktestTrade,
+    DCABacktester,
+    compare_strategies,
+)
 
 __all__ = [
     "DCASignalGenerator",
@@ -72,4 +83,11 @@ __all__ = [
     "EngineAction",
     "DealExitSignal",
     "FalseSignalFilter",
+    "DCAStrategyConfig",
+    "MarketPreset",
+    "MARKET_PRESETS",
+    "DCABacktester",
+    "BacktestResult",
+    "BacktestTrade",
+    "compare_strategies",
 ]

--- a/bot/strategies/dca/dca_backtester.py
+++ b/bot/strategies/dca/dca_backtester.py
@@ -1,0 +1,274 @@
+"""
+DCA Backtester — v2.0.
+
+Simulates DCA deal lifecycle on historical price data to compare
+exit strategies (Fixed TP vs Trailing Stop).
+
+Usage:
+    backtester = DCABacktester(order_config, trailing_config)
+    result = backtester.run(prices)
+    print(result.summary())
+"""
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+
+from bot.strategies.dca.dca_position_manager import DCAOrderConfig, DCAPositionManager
+from bot.strategies.dca.dca_trailing_stop import (
+    DCATrailingStop,
+    TrailingStopConfig,
+    TrailingStopSnapshot,
+)
+
+
+# =============================================================================
+# Data Structures
+# =============================================================================
+
+
+@dataclass
+class BacktestTrade:
+    """Record of a completed backtest trade."""
+
+    entry_price: Decimal
+    exit_price: Decimal
+    exit_reason: str
+    safety_orders_filled: int
+    profit: Decimal
+    profit_pct: Decimal
+    total_cost: Decimal
+
+
+@dataclass
+class BacktestResult:
+    """Aggregate results of a backtest run."""
+
+    trades: list[BacktestTrade] = field(default_factory=list)
+    label: str = ""
+
+    @property
+    def total_trades(self) -> int:
+        return len(self.trades)
+
+    @property
+    def winning_trades(self) -> int:
+        return sum(1 for t in self.trades if t.profit > 0)
+
+    @property
+    def losing_trades(self) -> int:
+        return sum(1 for t in self.trades if t.profit <= 0)
+
+    @property
+    def win_rate(self) -> Decimal:
+        if not self.trades:
+            return Decimal("0")
+        return Decimal(str(self.winning_trades)) / Decimal(str(self.total_trades))
+
+    @property
+    def total_profit(self) -> Decimal:
+        return sum((t.profit for t in self.trades), Decimal("0"))
+
+    @property
+    def avg_profit_pct(self) -> Decimal:
+        if not self.trades:
+            return Decimal("0")
+        return sum((t.profit_pct for t in self.trades), Decimal("0")) / Decimal(
+            str(self.total_trades)
+        )
+
+    @property
+    def max_profit_pct(self) -> Decimal:
+        if not self.trades:
+            return Decimal("0")
+        return max(t.profit_pct for t in self.trades)
+
+    @property
+    def max_loss_pct(self) -> Decimal:
+        if not self.trades:
+            return Decimal("0")
+        return min(t.profit_pct for t in self.trades)
+
+    @property
+    def profit_factor(self) -> Decimal:
+        gross_profit = sum(
+            (t.profit for t in self.trades if t.profit > 0), Decimal("0")
+        )
+        gross_loss = abs(
+            sum((t.profit for t in self.trades if t.profit < 0), Decimal("0"))
+        )
+        if gross_loss == 0:
+            return Decimal("999") if gross_profit > 0 else Decimal("0")
+        return gross_profit / gross_loss
+
+    def summary(self) -> dict[str, Any]:
+        """Return summary statistics."""
+        return {
+            "label": self.label,
+            "total_trades": self.total_trades,
+            "winning_trades": self.winning_trades,
+            "losing_trades": self.losing_trades,
+            "win_rate": str(self.win_rate),
+            "total_profit": str(self.total_profit),
+            "avg_profit_pct": str(self.avg_profit_pct),
+            "max_profit_pct": str(self.max_profit_pct),
+            "max_loss_pct": str(self.max_loss_pct),
+            "profit_factor": str(self.profit_factor),
+        }
+
+
+# =============================================================================
+# DCA Backtester
+# =============================================================================
+
+
+class DCABacktester:
+    """
+    Simulates DCA deals on a price series.
+
+    For each deal:
+    1. Opens base order at trigger price
+    2. Fills safety orders as price drops
+    3. Exits via trailing stop, fixed TP, or stop loss
+
+    The backtester opens a new deal when no deal is active,
+    simulating continuous operation.
+    """
+
+    def __init__(
+        self,
+        order_config: DCAOrderConfig | None = None,
+        trailing_config: TrailingStopConfig | None = None,
+        label: str = "",
+    ):
+        self._order_config = order_config or DCAOrderConfig()
+        self._trailing_config = trailing_config or TrailingStopConfig()
+        self._trailing_stop = DCATrailingStop(self._trailing_config)
+        self._label = label
+
+    def run(self, prices: list[Decimal]) -> BacktestResult:
+        """
+        Run backtest on a price series.
+
+        Args:
+            prices: List of prices (chronological order).
+
+        Returns:
+            BacktestResult with all completed trades.
+        """
+        result = BacktestResult(label=self._label)
+        pos_mgr = DCAPositionManager("BACKTEST", self._order_config)
+
+        deal = None
+        snapshot = None
+        i = 0
+
+        while i < len(prices):
+            price = prices[i]
+
+            if deal is None:
+                # Open new deal
+                deal = pos_mgr.open_deal(price)
+                snapshot = TrailingStopSnapshot(highest_price_since_entry=price)
+                i += 1
+                continue
+
+            # Update highest price
+            pos_mgr.update_highest_price(deal.id, price)
+            deal = pos_mgr.get_deal(deal.id)
+
+            # Check safety orders
+            so_trigger = pos_mgr.check_safety_order_trigger(deal.id, price)
+            if so_trigger is not None:
+                pos_mgr.fill_safety_order(deal.id, so_trigger.level, price)
+                deal = pos_mgr.get_deal(deal.id)
+
+            # Check exit conditions
+            exit_reason = self._check_exit(deal, price, snapshot)
+
+            if exit_reason is not None:
+                close_result = pos_mgr.close_deal(deal.id, price, exit_reason)
+                result.trades.append(
+                    BacktestTrade(
+                        entry_price=deal.base_order_price,
+                        exit_price=price,
+                        exit_reason=exit_reason,
+                        safety_orders_filled=deal.safety_orders_filled,
+                        profit=close_result.realized_profit,
+                        profit_pct=close_result.realized_profit_pct,
+                        total_cost=deal.total_cost,
+                    )
+                )
+                deal = None
+                snapshot = None
+
+            i += 1
+
+        return result
+
+    def _check_exit(
+        self,
+        deal: Any,
+        current_price: Decimal,
+        snapshot: TrailingStopSnapshot | None,
+    ) -> str | None:
+        """Check all exit conditions. Returns reason or None."""
+
+        # Trailing stop
+        if self._trailing_stop.enabled:
+            ts_result = self._trailing_stop.evaluate(
+                current_price=current_price,
+                average_entry=deal.average_entry_price,
+                highest_price=deal.highest_price_since_entry,
+                snapshot=snapshot,
+            )
+            if ts_result.should_exit:
+                return "trailing_stop"
+
+        # Fixed take profit (when trailing not enabled)
+        if not self._trailing_stop.enabled:
+            tp_pct = self._order_config.take_profit_pct
+            tp_price = deal.average_entry_price * (1 + tp_pct / 100)
+            if current_price >= tp_price:
+                return "take_profit"
+
+        # Stop loss (always active)
+        sl_pct = self._order_config.stop_loss_pct
+        sl_price = deal.average_entry_price * (1 - sl_pct / 100)
+        if current_price <= sl_price:
+            return "stop_loss"
+
+        return None
+
+
+def compare_strategies(
+    prices: list[Decimal],
+    order_config: DCAOrderConfig | None = None,
+    trailing_config: TrailingStopConfig | None = None,
+) -> dict[str, BacktestResult]:
+    """
+    Compare Fixed TP vs Trailing Stop on the same price data.
+
+    Returns dict with "fixed_tp" and "trailing_stop" results.
+    """
+    cfg = order_config or DCAOrderConfig()
+
+    # Fixed TP backtester (trailing disabled)
+    fixed_bt = DCABacktester(
+        order_config=cfg,
+        trailing_config=TrailingStopConfig(enabled=False),
+        label="Fixed TP",
+    )
+
+    # Trailing stop backtester
+    ts_config = trailing_config or TrailingStopConfig()
+    trailing_bt = DCABacktester(
+        order_config=cfg,
+        trailing_config=ts_config,
+        label="Trailing Stop",
+    )
+
+    return {
+        "fixed_tp": fixed_bt.run(prices),
+        "trailing_stop": trailing_bt.run(prices),
+    }

--- a/bot/strategies/dca/dca_config.py
+++ b/bot/strategies/dca/dca_config.py
@@ -1,0 +1,393 @@
+"""
+DCA Strategy Configuration — v2.0 with market presets.
+
+Provides YAML-compatible configuration for DCA strategy with:
+- Market-based presets (conservative, moderate, aggressive)
+- Signal, order, risk, and trailing stop config mapping
+- Validation and serialization
+"""
+
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, model_validator
+
+from bot.strategies.dca.dca_signal_generator import DCASignalConfig, TrendDirection
+from bot.strategies.dca.dca_position_manager import DCAOrderConfig
+from bot.strategies.dca.dca_risk_manager import DCARiskConfig
+from bot.strategies.dca.dca_trailing_stop import TrailingStopConfig, TrailingStopType
+from bot.strategies.dca.dca_engine import FalseSignalFilter
+
+
+# =============================================================================
+# Market Presets
+# =============================================================================
+
+
+class MarketPreset(str, Enum):
+    """Market regime for DCA configuration."""
+
+    CONSERVATIVE = "conservative"  # Stable markets, tight parameters
+    MODERATE = "moderate"  # BTC/ETH normal conditions
+    AGGRESSIVE = "aggressive"  # Altcoins, volatile markets
+    CUSTOM = "custom"  # User-defined
+
+
+MARKET_PRESETS: dict[str, dict[str, Any]] = {
+    "conservative": {
+        "signal": {
+            "trend_direction": "down",
+            "min_trend_strength": 25.0,
+            "require_confluence": True,
+            "min_confluence_score": 0.7,
+            "max_concurrent_deals": 2,
+            "max_daily_loss": "300",
+            "min_seconds_between_deals": 300,
+        },
+        "order": {
+            "base_order_volume": "50",
+            "max_safety_orders": 3,
+            "volume_multiplier": "1.3",
+            "price_step_pct": "1.5",
+            "take_profit_pct": "2.0",
+            "stop_loss_pct": "8.0",
+            "max_position_cost": "3000",
+        },
+        "risk": {
+            "max_concurrent_deals": 2,
+            "max_total_exposure": "5000",
+            "max_daily_loss": "300",
+            "max_deal_drawdown_pct": "12.0",
+            "max_portfolio_drawdown_pct": "5.0",
+            "max_consecutive_losses": 5,
+            "max_price_change_pct": "8.0",
+            "min_balance_pct": "0.30",
+        },
+        "trailing": {
+            "enabled": True,
+            "activation_pct": "2.0",
+            "distance_pct": "0.6",
+            "stop_type": "percentage",
+        },
+        "filter": {
+            "confirmation_count": 2,
+            "min_rejection_cooldown": 60,
+            "max_recent_price_change_pct": "3.0",
+        },
+    },
+    "moderate": {
+        "signal": {
+            "trend_direction": "down",
+            "min_trend_strength": 20.0,
+            "require_confluence": True,
+            "min_confluence_score": 0.6,
+            "max_concurrent_deals": 3,
+            "max_daily_loss": "500",
+            "min_seconds_between_deals": 120,
+        },
+        "order": {
+            "base_order_volume": "100",
+            "max_safety_orders": 5,
+            "volume_multiplier": "1.5",
+            "price_step_pct": "2.0",
+            "take_profit_pct": "3.0",
+            "stop_loss_pct": "10.0",
+            "max_position_cost": "5000",
+        },
+        "risk": {
+            "max_concurrent_deals": 3,
+            "max_total_exposure": "10000",
+            "max_daily_loss": "500",
+            "max_deal_drawdown_pct": "15.0",
+            "max_portfolio_drawdown_pct": "10.0",
+            "max_consecutive_losses": 4,
+            "max_price_change_pct": "10.0",
+            "min_balance_pct": "0.20",
+        },
+        "trailing": {
+            "enabled": True,
+            "activation_pct": "1.5",
+            "distance_pct": "0.8",
+            "stop_type": "percentage",
+        },
+        "filter": {
+            "confirmation_count": 1,
+            "min_rejection_cooldown": 30,
+            "max_recent_price_change_pct": "5.0",
+        },
+    },
+    "aggressive": {
+        "signal": {
+            "trend_direction": "down",
+            "min_trend_strength": 15.0,
+            "require_confluence": True,
+            "min_confluence_score": 0.5,
+            "max_concurrent_deals": 5,
+            "max_daily_loss": "1000",
+            "min_seconds_between_deals": 60,
+        },
+        "order": {
+            "base_order_volume": "200",
+            "max_safety_orders": 7,
+            "volume_multiplier": "1.8",
+            "price_step_pct": "3.0",
+            "take_profit_pct": "5.0",
+            "stop_loss_pct": "15.0",
+            "max_position_cost": "15000",
+        },
+        "risk": {
+            "max_concurrent_deals": 5,
+            "max_total_exposure": "25000",
+            "max_daily_loss": "1000",
+            "max_deal_drawdown_pct": "20.0",
+            "max_portfolio_drawdown_pct": "15.0",
+            "max_consecutive_losses": 3,
+            "max_price_change_pct": "15.0",
+            "min_balance_pct": "0.15",
+        },
+        "trailing": {
+            "enabled": True,
+            "activation_pct": "2.5",
+            "distance_pct": "1.0",
+            "stop_type": "percentage",
+        },
+        "filter": {
+            "confirmation_count": 1,
+            "min_rejection_cooldown": 0,
+            "max_recent_price_change_pct": "8.0",
+        },
+    },
+}
+
+
+# =============================================================================
+# Pydantic Schemas
+# =============================================================================
+
+
+class DCASignalSchema(BaseModel):
+    """Signal generator settings."""
+
+    trend_direction: str = Field(default="down", pattern="^(down|up)$")
+    min_trend_strength: float = Field(default=20.0, ge=0, le=100)
+    entry_price_min: Decimal | None = Field(default=None, gt=0)
+    entry_price_max: Decimal | None = Field(default=None, gt=0)
+    require_confluence: bool = Field(default=True)
+    min_confluence_score: float = Field(default=0.6, ge=0, le=1)
+    max_concurrent_deals: int = Field(default=3, ge=1, le=20)
+    max_daily_loss: Decimal = Field(default=Decimal("500"), gt=0)
+    min_seconds_between_deals: int = Field(default=120, ge=0)
+
+    def to_signal_config(self) -> DCASignalConfig:
+        """Convert to DCASignalConfig dataclass."""
+        return DCASignalConfig(
+            trend_direction=TrendDirection(self.trend_direction),
+            min_trend_strength=self.min_trend_strength,
+            entry_price_min=self.entry_price_min,
+            entry_price_max=self.entry_price_max,
+            require_confluence=self.require_confluence,
+            min_confluence_score=self.min_confluence_score,
+            max_concurrent_deals=self.max_concurrent_deals,
+            max_daily_loss=self.max_daily_loss,
+            min_seconds_between_deals=self.min_seconds_between_deals,
+        )
+
+
+class DCAOrderSchema(BaseModel):
+    """Order/position settings."""
+
+    base_order_volume: Decimal = Field(default=Decimal("100"), gt=0)
+    max_safety_orders: int = Field(default=5, ge=0, le=20)
+    volume_multiplier: Decimal = Field(default=Decimal("1.5"), gt=0)
+    price_step_pct: Decimal = Field(default=Decimal("2.0"), gt=0, le=50)
+    take_profit_pct: Decimal = Field(default=Decimal("3.0"), gt=0, le=100)
+    stop_loss_pct: Decimal = Field(default=Decimal("10.0"), gt=0, le=100)
+    max_position_cost: Decimal = Field(default=Decimal("5000"), gt=0)
+
+    def to_order_config(self) -> DCAOrderConfig:
+        """Convert to DCAOrderConfig dataclass."""
+        return DCAOrderConfig(
+            base_order_volume=self.base_order_volume,
+            max_safety_orders=self.max_safety_orders,
+            volume_multiplier=self.volume_multiplier,
+            price_step_pct=self.price_step_pct,
+            take_profit_pct=self.take_profit_pct,
+            stop_loss_pct=self.stop_loss_pct,
+            max_position_cost=self.max_position_cost,
+        )
+
+
+class DCARiskSchema(BaseModel):
+    """Risk management settings."""
+
+    max_concurrent_deals: int = Field(default=3, ge=1, le=20)
+    max_total_exposure: Decimal = Field(default=Decimal("10000"), gt=0)
+    max_daily_loss: Decimal = Field(default=Decimal("500"), gt=0)
+    max_deal_drawdown_pct: Decimal = Field(default=Decimal("15.0"), gt=0, le=100)
+    max_portfolio_drawdown_pct: Decimal = Field(default=Decimal("10.0"), gt=0, le=100)
+    max_consecutive_losses: int = Field(default=4, ge=1, le=20)
+    max_price_change_pct: Decimal = Field(default=Decimal("10.0"), gt=0, le=100)
+    min_balance_pct: Decimal = Field(default=Decimal("0.20"), ge=0, le=1)
+
+    def to_risk_config(self) -> DCARiskConfig:
+        """Convert to DCARiskConfig dataclass."""
+        return DCARiskConfig(
+            max_concurrent_deals=self.max_concurrent_deals,
+            max_total_exposure=self.max_total_exposure,
+            max_daily_loss=self.max_daily_loss,
+            max_deal_drawdown_pct=self.max_deal_drawdown_pct,
+            max_portfolio_drawdown_pct=self.max_portfolio_drawdown_pct,
+            max_consecutive_losses=self.max_consecutive_losses,
+            max_price_change_pct=self.max_price_change_pct,
+            min_balance_pct=self.min_balance_pct,
+        )
+
+
+class DCATrailingSchema(BaseModel):
+    """Trailing stop settings."""
+
+    enabled: bool = Field(default=True)
+    activation_pct: Decimal = Field(default=Decimal("1.5"), ge=0)
+    distance_pct: Decimal = Field(default=Decimal("0.8"), gt=0)
+    distance_abs: Decimal = Field(default=Decimal("25"), gt=0)
+    stop_type: str = Field(default="percentage", pattern="^(percentage|absolute)$")
+
+    def to_trailing_config(self) -> TrailingStopConfig:
+        """Convert to TrailingStopConfig dataclass."""
+        return TrailingStopConfig(
+            enabled=self.enabled,
+            activation_pct=self.activation_pct,
+            distance_pct=self.distance_pct,
+            distance_abs=self.distance_abs,
+            stop_type=TrailingStopType(self.stop_type),
+        )
+
+
+class DCAFilterSchema(BaseModel):
+    """False signal filter settings."""
+
+    confirmation_count: int = Field(default=1, ge=1, le=10)
+    min_rejection_cooldown: int = Field(default=30, ge=0)
+    max_recent_price_change_pct: Decimal = Field(default=Decimal("5.0"), gt=0)
+
+    def to_filter(self) -> FalseSignalFilter:
+        """Convert to FalseSignalFilter dataclass."""
+        return FalseSignalFilter(
+            confirmation_count=self.confirmation_count,
+            min_rejection_cooldown=self.min_rejection_cooldown,
+            max_recent_price_change_pct=self.max_recent_price_change_pct,
+        )
+
+
+# =============================================================================
+# DCA Strategy Config
+# =============================================================================
+
+
+class DCAStrategyConfig(BaseModel):
+    """
+    Complete DCA strategy configuration (v2.0).
+
+    Can be loaded from YAML with market presets or custom values.
+    """
+
+    # General
+    symbol: str = Field(..., description="Trading pair (e.g., BTC/USDT)")
+    market_preset: MarketPreset = Field(
+        default=MarketPreset.MODERATE,
+        description="Market regime preset",
+    )
+
+    # Component configs
+    signal: DCASignalSchema = Field(default_factory=DCASignalSchema)
+    order: DCAOrderSchema = Field(default_factory=DCAOrderSchema)
+    risk: DCARiskSchema = Field(default_factory=DCARiskSchema)
+    trailing: DCATrailingSchema = Field(default_factory=DCATrailingSchema)
+    filter: DCAFilterSchema = Field(default_factory=DCAFilterSchema)
+
+    # Operational
+    dry_run: bool = Field(default=False)
+
+    @model_validator(mode="after")
+    def validate_consistency(self) -> "DCAStrategyConfig":
+        """Validate cross-field consistency."""
+        if self.signal.max_concurrent_deals != self.risk.max_concurrent_deals:
+            self.risk.max_concurrent_deals = self.signal.max_concurrent_deals
+        if self.signal.max_daily_loss != self.risk.max_daily_loss:
+            self.risk.max_daily_loss = self.signal.max_daily_loss
+        return self
+
+    def to_signal_config(self) -> DCASignalConfig:
+        """Convert signal section to DCASignalConfig."""
+        return self.signal.to_signal_config()
+
+    def to_order_config(self) -> DCAOrderConfig:
+        """Convert order section to DCAOrderConfig."""
+        return self.order.to_order_config()
+
+    def to_risk_config(self) -> DCARiskConfig:
+        """Convert risk section to DCARiskConfig."""
+        return self.risk.to_risk_config()
+
+    def to_trailing_config(self) -> TrailingStopConfig:
+        """Convert trailing section to TrailingStopConfig."""
+        return self.trailing.to_trailing_config()
+
+    def to_filter(self) -> FalseSignalFilter:
+        """Convert filter section to FalseSignalFilter."""
+        return self.filter.to_filter()
+
+    @classmethod
+    def from_preset(
+        cls, symbol: str, preset: MarketPreset, **overrides: Any
+    ) -> "DCAStrategyConfig":
+        """
+        Create config from a market preset with optional overrides.
+
+        Args:
+            symbol: Trading pair.
+            preset: Market preset.
+            **overrides: Override any preset value.
+
+        Returns:
+            DCAStrategyConfig instance.
+        """
+        if preset == MarketPreset.CUSTOM:
+            return cls(symbol=symbol, market_preset=preset, **overrides)
+
+        preset_data = MARKET_PRESETS[preset.value]
+        sections: dict[str, Any] = {}
+
+        for section_name in ("signal", "order", "risk", "trailing", "filter"):
+            section_preset = preset_data.get(section_name, {}).copy()
+            section_override = overrides.pop(section_name, {})
+            if isinstance(section_override, dict):
+                section_preset.update(section_override)
+            sections[section_name] = section_preset
+
+        return cls(
+            symbol=symbol,
+            market_preset=preset,
+            **sections,
+            **overrides,
+        )
+
+    def to_yaml(self) -> str:
+        """Serialize to YAML string."""
+        data = self.model_dump(mode="json")
+        return yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+
+    @classmethod
+    def from_yaml(cls, yaml_str: str) -> "DCAStrategyConfig":
+        """Load from YAML string."""
+        data = yaml.safe_load(yaml_str)
+        return cls(**data)
+
+    @classmethod
+    def from_yaml_file(cls, path: str) -> "DCAStrategyConfig":
+        """Load from YAML file."""
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        return cls(**data)

--- a/tests/strategies/dca/test_dca_config.py
+++ b/tests/strategies/dca/test_dca_config.py
@@ -1,0 +1,557 @@
+"""Tests for DCA Strategy Configuration v2.0.
+
+Tests market presets, YAML serialization, config-to-component mapping,
+integration tests with mock exchange, and backtesting comparison.
+"""
+
+from decimal import Decimal
+
+import pytest
+import yaml
+
+from bot.strategies.dca.dca_config import (
+    DCAFilterSchema,
+    DCAOrderSchema,
+    DCARiskSchema,
+    DCASignalSchema,
+    DCAStrategyConfig,
+    DCATrailingSchema,
+    MARKET_PRESETS,
+    MarketPreset,
+)
+from bot.strategies.dca.dca_engine import DCAEngine, FalseSignalFilter
+from bot.strategies.dca.dca_position_manager import DCAOrderConfig
+from bot.strategies.dca.dca_risk_manager import DCARiskConfig
+from bot.strategies.dca.dca_signal_generator import (
+    DCASignalConfig,
+    MarketState,
+    TrendDirection,
+)
+from bot.strategies.dca.dca_trailing_stop import TrailingStopConfig, TrailingStopType
+from bot.strategies.dca.dca_backtester import (
+    BacktestResult,
+    BacktestTrade,
+    DCABacktester,
+    compare_strategies,
+)
+
+
+# =========================================================================
+# Market Presets Tests
+# =========================================================================
+
+
+class TestMarketPresets:
+    def test_all_presets_exist(self):
+        assert "conservative" in MARKET_PRESETS
+        assert "moderate" in MARKET_PRESETS
+        assert "aggressive" in MARKET_PRESETS
+
+    def test_conservative_preset(self):
+        cfg = DCAStrategyConfig.from_preset("BTC/USDT", MarketPreset.CONSERVATIVE)
+        assert cfg.signal.min_confluence_score == 0.7
+        assert cfg.order.base_order_volume == Decimal("50")
+        assert cfg.order.max_safety_orders == 3
+        assert cfg.risk.max_concurrent_deals == 2
+        assert cfg.trailing.activation_pct == Decimal("2.0")
+        assert cfg.filter.confirmation_count == 2
+
+    def test_moderate_preset(self):
+        cfg = DCAStrategyConfig.from_preset("ETH/USDT", MarketPreset.MODERATE)
+        assert cfg.signal.min_confluence_score == 0.6
+        assert cfg.order.base_order_volume == Decimal("100")
+        assert cfg.order.max_safety_orders == 5
+        assert cfg.risk.max_concurrent_deals == 3
+        assert cfg.trailing.activation_pct == Decimal("1.5")
+
+    def test_aggressive_preset(self):
+        cfg = DCAStrategyConfig.from_preset("DOGE/USDT", MarketPreset.AGGRESSIVE)
+        assert cfg.signal.min_confluence_score == 0.5
+        assert cfg.order.base_order_volume == Decimal("200")
+        assert cfg.order.max_safety_orders == 7
+        assert cfg.risk.max_concurrent_deals == 5
+        assert cfg.trailing.activation_pct == Decimal("2.5")
+
+    def test_preset_with_overrides(self):
+        cfg = DCAStrategyConfig.from_preset(
+            "BTC/USDT",
+            MarketPreset.MODERATE,
+            order={"base_order_volume": "250", "max_safety_orders": 8},
+        )
+        assert cfg.order.base_order_volume == Decimal("250")
+        assert cfg.order.max_safety_orders == 8
+        # Other values from preset
+        assert cfg.order.price_step_pct == Decimal("2.0")
+
+    def test_preset_with_risk_override(self):
+        cfg = DCAStrategyConfig.from_preset(
+            "BTC/USDT",
+            MarketPreset.CONSERVATIVE,
+            risk={"max_total_exposure": "20000"},
+        )
+        assert cfg.risk.max_total_exposure == Decimal("20000")
+        # Other risk values from preset
+        assert cfg.risk.max_portfolio_drawdown_pct == Decimal("5.0")
+
+    def test_custom_mode(self):
+        cfg = DCAStrategyConfig.from_preset(
+            "BTC/USDT",
+            MarketPreset.CUSTOM,
+            order={"base_order_volume": "500", "max_safety_orders": 10},
+        )
+        assert cfg.market_preset == MarketPreset.CUSTOM
+        assert cfg.order.base_order_volume == Decimal("500")
+
+    def test_preset_sections_complete(self):
+        for name, preset in MARKET_PRESETS.items():
+            assert "signal" in preset, f"{name} missing signal"
+            assert "order" in preset, f"{name} missing order"
+            assert "risk" in preset, f"{name} missing risk"
+            assert "trailing" in preset, f"{name} missing trailing"
+            assert "filter" in preset, f"{name} missing filter"
+
+
+# =========================================================================
+# DCAStrategyConfig Tests
+# =========================================================================
+
+
+class TestDCAStrategyConfig:
+    def test_defaults(self):
+        cfg = DCAStrategyConfig(symbol="BTC/USDT")
+        assert cfg.market_preset == MarketPreset.MODERATE
+        assert cfg.dry_run is False
+
+    def test_consistency_validator(self):
+        cfg = DCAStrategyConfig(
+            symbol="BTC/USDT",
+            signal=DCASignalSchema(max_concurrent_deals=5, max_daily_loss=Decimal("800")),
+            risk=DCARiskSchema(max_concurrent_deals=3, max_daily_loss=Decimal("500")),
+        )
+        # Validator syncs risk to signal values
+        assert cfg.risk.max_concurrent_deals == 5
+        assert cfg.risk.max_daily_loss == Decimal("800")
+
+    def test_to_signal_config(self):
+        cfg = DCAStrategyConfig.from_preset("BTC/USDT", MarketPreset.MODERATE)
+        sc = cfg.to_signal_config()
+        assert isinstance(sc, DCASignalConfig)
+        assert sc.trend_direction == TrendDirection.DOWN
+        assert sc.min_trend_strength == 20.0
+
+    def test_to_order_config(self):
+        cfg = DCAStrategyConfig.from_preset("BTC/USDT", MarketPreset.MODERATE)
+        oc = cfg.to_order_config()
+        assert isinstance(oc, DCAOrderConfig)
+        assert oc.base_order_volume == Decimal("100")
+        assert oc.max_safety_orders == 5
+
+    def test_to_risk_config(self):
+        cfg = DCAStrategyConfig.from_preset("BTC/USDT", MarketPreset.MODERATE)
+        rc = cfg.to_risk_config()
+        assert isinstance(rc, DCARiskConfig)
+        assert rc.max_total_exposure == Decimal("10000")
+        assert rc.max_deal_drawdown_pct == Decimal("15.0")
+
+    def test_to_trailing_config(self):
+        cfg = DCAStrategyConfig.from_preset("BTC/USDT", MarketPreset.MODERATE)
+        tc = cfg.to_trailing_config()
+        assert isinstance(tc, TrailingStopConfig)
+        assert tc.enabled is True
+        assert tc.activation_pct == Decimal("1.5")
+
+    def test_to_filter(self):
+        cfg = DCAStrategyConfig.from_preset("BTC/USDT", MarketPreset.MODERATE)
+        flt = cfg.to_filter()
+        assert isinstance(flt, FalseSignalFilter)
+        assert flt.confirmation_count == 1
+
+
+# =========================================================================
+# YAML Serialization Tests
+# =========================================================================
+
+
+class TestYAMLSerialization:
+    def test_to_yaml(self):
+        cfg = DCAStrategyConfig(symbol="BTC/USDT")
+        yaml_str = cfg.to_yaml()
+        assert "BTC/USDT" in yaml_str
+        assert "signal" in yaml_str
+        assert "order" in yaml_str
+        assert "risk" in yaml_str
+        assert "trailing" in yaml_str
+
+    def test_from_yaml_roundtrip(self):
+        original = DCAStrategyConfig.from_preset("ETH/USDT", MarketPreset.AGGRESSIVE)
+        yaml_str = original.to_yaml()
+        loaded = DCAStrategyConfig.from_yaml(yaml_str)
+        assert loaded.symbol == "ETH/USDT"
+        assert loaded.order.base_order_volume == original.order.base_order_volume
+        assert loaded.trailing.activation_pct == original.trailing.activation_pct
+
+    def test_from_yaml_file(self, tmp_path):
+        cfg = DCAStrategyConfig.from_preset("BTC/USDT", MarketPreset.CONSERVATIVE)
+        file_path = tmp_path / "dca_config.yaml"
+        file_path.write_text(cfg.to_yaml())
+
+        loaded = DCAStrategyConfig.from_yaml_file(str(file_path))
+        assert loaded.symbol == "BTC/USDT"
+        assert loaded.order.max_safety_orders == 3
+
+    def test_yaml_includes_all_fields(self):
+        cfg = DCAStrategyConfig(symbol="BTC/USDT")
+        data = yaml.safe_load(cfg.to_yaml())
+        assert "symbol" in data
+        assert "market_preset" in data
+        assert "signal" in data
+        assert "order" in data
+        assert "risk" in data
+        assert "trailing" in data
+        assert "filter" in data
+        assert "dry_run" in data
+
+    def test_preset_yaml_roundtrip_all_modes(self):
+        for preset in [MarketPreset.CONSERVATIVE, MarketPreset.MODERATE, MarketPreset.AGGRESSIVE]:
+            cfg = DCAStrategyConfig.from_preset("BTC/USDT", preset)
+            yaml_str = cfg.to_yaml()
+            loaded = DCAStrategyConfig.from_yaml(yaml_str)
+            assert loaded.order.base_order_volume == cfg.order.base_order_volume
+            assert loaded.trailing.activation_pct == cfg.trailing.activation_pct
+
+
+# =========================================================================
+# Schema Tests
+# =========================================================================
+
+
+class TestSchemas:
+    def test_signal_schema_defaults(self):
+        s = DCASignalSchema()
+        assert s.trend_direction == "down"
+        assert s.min_trend_strength == 20.0
+
+    def test_signal_schema_to_config(self):
+        s = DCASignalSchema(trend_direction="up", min_trend_strength=30.0)
+        sc = s.to_signal_config()
+        assert sc.trend_direction == TrendDirection.UP
+        assert sc.min_trend_strength == 30.0
+
+    def test_order_schema_defaults(self):
+        o = DCAOrderSchema()
+        assert o.base_order_volume == Decimal("100")
+        assert o.max_safety_orders == 5
+
+    def test_risk_schema_to_config(self):
+        r = DCARiskSchema(max_total_exposure=Decimal("20000"), max_deal_drawdown_pct=Decimal("18.0"))
+        rc = r.to_risk_config()
+        assert isinstance(rc, DCARiskConfig)
+        assert rc.max_total_exposure == Decimal("20000")
+        assert rc.max_deal_drawdown_pct == Decimal("18.0")
+
+    def test_trailing_schema_absolute_type(self):
+        t = DCATrailingSchema(stop_type="absolute", distance_abs=Decimal("50"))
+        tc = t.to_trailing_config()
+        assert tc.stop_type == TrailingStopType.ABSOLUTE
+        assert tc.distance_abs == Decimal("50")
+
+    def test_filter_schema_defaults(self):
+        f = DCAFilterSchema()
+        assert f.confirmation_count == 1
+        assert f.min_rejection_cooldown == 30
+
+    def test_invalid_trend_direction(self):
+        with pytest.raises(ValueError):
+            DCASignalSchema(trend_direction="sideways")
+
+    def test_invalid_stop_type(self):
+        with pytest.raises(ValueError):
+            DCATrailingSchema(stop_type="invalid")
+
+
+# =========================================================================
+# Integration Tests — Full Engine from Config
+# =========================================================================
+
+
+class TestIntegrationFromConfig:
+    def test_engine_from_config(self):
+        cfg = DCAStrategyConfig.from_preset("BTC/USDT", MarketPreset.MODERATE)
+        engine = DCAEngine(
+            symbol=cfg.symbol,
+            signal_config=cfg.to_signal_config(),
+            order_config=cfg.to_order_config(),
+            risk_config=cfg.to_risk_config(),
+            trailing_config=cfg.to_trailing_config(),
+            false_signal_filter=cfg.to_filter(),
+        )
+        assert engine.symbol == "BTC/USDT"
+        stats = engine.get_statistics()
+        assert stats["symbol"] == "BTC/USDT"
+
+    def test_full_cycle_from_config(self):
+        """Integration: config → engine → open → monitor → close."""
+        cfg = DCAStrategyConfig.from_preset("BTC/USDT", MarketPreset.MODERATE)
+        engine = DCAEngine(
+            symbol=cfg.symbol,
+            signal_config=cfg.to_signal_config(),
+            order_config=cfg.to_order_config(),
+            risk_config=cfg.to_risk_config(),
+            trailing_config=cfg.to_trailing_config(),
+            false_signal_filter=cfg.to_filter(),
+        )
+
+        # Open deal
+        deal = engine.open_deal(Decimal("3100"))
+        assert deal.symbol == "BTC/USDT"
+
+        # Price rises past activation (1.5% = 3146.5) and trailing
+        for price in [3150, 3200, 3300, 3400]:
+            state = MarketState(current_price=Decimal(str(price)))
+            engine.on_price_update(
+                state,
+                available_balance=Decimal("5000"),
+                total_balance=Decimal("10000"),
+            )
+
+        # Drop below trailing stop (3400 * 0.992 = 3372.8)
+        state = MarketState(current_price=Decimal("3370"))
+        action = engine.on_price_update(
+            state,
+            available_balance=Decimal("5000"),
+            total_balance=Decimal("10000"),
+        )
+        assert len(action.deals_to_close) == 1
+        assert action.deals_to_close[0].reason == "trailing_stop"
+
+        # Close and verify profit
+        result = engine.close_deal(deal.id, Decimal("3370"), "trailing_stop")
+        assert result.realized_profit > 0
+
+    def test_conservative_blocks_more_deals(self):
+        """Conservative preset only allows 2 concurrent deals."""
+        cfg = DCAStrategyConfig.from_preset("BTC/USDT", MarketPreset.CONSERVATIVE)
+        engine = DCAEngine(
+            symbol=cfg.symbol,
+            signal_config=cfg.to_signal_config(),
+            order_config=cfg.to_order_config(),
+            risk_config=cfg.to_risk_config(),
+            trailing_config=cfg.to_trailing_config(),
+            false_signal_filter=cfg.to_filter(),
+        )
+
+        engine.open_deal(Decimal("3100"))
+        engine.open_deal(Decimal("3200"))
+
+        # Third deal should be blocked by risk check
+        state = MarketState(
+            current_price=Decimal("3000"),
+            ema_fast=Decimal("2950"),
+            ema_slow=Decimal("3100"),
+            adx=30.0,
+            rsi=25.0,
+            volume_24h=Decimal("2000000"),
+            avg_volume=Decimal("1000000"),
+            bb_lower=Decimal("2980"),
+            nearest_support=Decimal("2950"),
+        )
+        action = engine.on_price_update(
+            state,
+            available_balance=Decimal("5000"),
+            total_balance=Decimal("10000"),
+        )
+        assert action.should_open_deal is False
+
+    def test_yaml_config_creates_working_engine(self):
+        """YAML roundtrip produces config that creates a working engine."""
+        original = DCAStrategyConfig.from_preset("ETH/USDT", MarketPreset.AGGRESSIVE)
+        yaml_str = original.to_yaml()
+        loaded = DCAStrategyConfig.from_yaml(yaml_str)
+
+        engine = DCAEngine(
+            symbol=loaded.symbol,
+            signal_config=loaded.to_signal_config(),
+            order_config=loaded.to_order_config(),
+            risk_config=loaded.to_risk_config(),
+            trailing_config=loaded.to_trailing_config(),
+            false_signal_filter=loaded.to_filter(),
+        )
+        deal = engine.open_deal(Decimal("2000"))
+        assert deal.symbol == "ETH/USDT"
+
+
+# =========================================================================
+# Backtester Tests
+# =========================================================================
+
+
+class TestBacktester:
+    @pytest.fixture
+    def order_config(self):
+        return DCAOrderConfig(
+            base_order_volume=Decimal("100"),
+            max_safety_orders=3,
+            volume_multiplier=Decimal("1.5"),
+            price_step_pct=Decimal("2.0"),
+            take_profit_pct=Decimal("3.0"),
+            stop_loss_pct=Decimal("10.0"),
+            max_position_cost=Decimal("5000"),
+        )
+
+    def test_backtester_fixed_tp(self, order_config):
+        """Fixed TP exits at take profit price."""
+        # Price drops then recovers past TP
+        prices = [Decimal(str(p)) for p in [
+            3100, 3050, 3000, 3050, 3100, 3150, 3200, 3250,
+        ]]
+        bt = DCABacktester(
+            order_config=order_config,
+            trailing_config=TrailingStopConfig(enabled=False),
+            label="Fixed TP",
+        )
+        result = bt.run(prices)
+        assert result.total_trades >= 1
+        assert result.trades[0].exit_reason == "take_profit"
+        assert result.trades[0].profit > 0
+
+    def test_backtester_trailing_stop(self, order_config):
+        """Trailing stop captures extended move."""
+        # Price rises well past TP level, then drops to trigger trailing
+        prices = [Decimal(str(p)) for p in [
+            3100, 3200, 3300, 3400, 3500, 3600,
+            3700, 3650,  # Drop to trigger trailing (3700*0.992=3674.4)
+        ]]
+        bt = DCABacktester(
+            order_config=order_config,
+            trailing_config=TrailingStopConfig(
+                enabled=True,
+                activation_pct=Decimal("1.5"),
+                distance_pct=Decimal("0.8"),
+            ),
+            label="Trailing Stop",
+        )
+        result = bt.run(prices)
+        assert result.total_trades >= 1
+        assert result.trades[0].exit_reason == "trailing_stop"
+        assert result.trades[0].profit > 0
+
+    def test_backtester_stop_loss(self, order_config):
+        """Stop loss triggers on large drop."""
+        # Use no safety orders config for clean SL test
+        no_so_config = DCAOrderConfig(
+            base_order_volume=Decimal("100"),
+            max_safety_orders=0,
+            take_profit_pct=Decimal("3.0"),
+            stop_loss_pct=Decimal("10.0"),
+            max_position_cost=Decimal("5000"),
+        )
+        prices = [Decimal(str(p)) for p in [
+            3100, 3000, 2900, 2780,  # Below SL (3100*0.9=2790)
+        ]]
+        bt = DCABacktester(
+            order_config=no_so_config,
+            trailing_config=TrailingStopConfig(enabled=False),
+        )
+        result = bt.run(prices)
+        assert result.total_trades >= 1
+        sl_trades = [t for t in result.trades if t.exit_reason == "stop_loss"]
+        assert len(sl_trades) >= 1
+
+    def test_backtester_safety_orders_fill(self, order_config):
+        """Safety orders fill as price drops."""
+        prices = [Decimal(str(p)) for p in [
+            3100, 3030, 2960, 2890,  # SO1, SO2, SO3 triggers
+            3000, 3100, 3200, 3300,  # Recovery past TP
+        ]]
+        bt = DCABacktester(
+            order_config=order_config,
+            trailing_config=TrailingStopConfig(enabled=False),
+        )
+        result = bt.run(prices)
+        assert result.total_trades >= 1
+        assert result.trades[0].safety_orders_filled > 0
+
+    def test_backtester_multiple_deals(self, order_config):
+        """Multiple sequential deals."""
+        # Deal 1: opens at 3100, TP at 3100*1.03=3193, exits at 3200
+        # Deal 2: opens at 3250 (next price after exit), TP at 3250*1.03=3347.5, exits at 3400
+        prices = [Decimal(str(p)) for p in [
+            3100, 3150, 3200,  # Deal 1 TP at 3200
+            3250, 3300, 3400,  # Deal 2 TP at 3400
+        ]]
+        bt = DCABacktester(
+            order_config=order_config,
+            trailing_config=TrailingStopConfig(enabled=False),
+        )
+        result = bt.run(prices)
+        assert result.total_trades >= 2
+
+    def test_backtest_result_metrics(self, order_config):
+        """BacktestResult computes metrics correctly."""
+        prices = [Decimal(str(p)) for p in [
+            3100, 3200, 3300,  # TP
+            3100, 3200, 3300,  # TP
+        ]]
+        bt = DCABacktester(
+            order_config=order_config,
+            trailing_config=TrailingStopConfig(enabled=False),
+        )
+        result = bt.run(prices)
+        assert result.total_trades >= 1
+        assert result.winning_trades >= 1
+        assert result.win_rate > 0
+        assert result.total_profit > 0
+        assert result.avg_profit_pct > 0
+        assert result.profit_factor > 0
+
+        summary = result.summary()
+        assert "total_trades" in summary
+        assert "win_rate" in summary
+        assert "profit_factor" in summary
+
+    def test_compare_strategies(self, order_config):
+        """Compare Fixed TP vs Trailing Stop."""
+        # Price rises well above TP then drops
+        prices = [Decimal(str(p)) for p in [
+            3100, 3200, 3300, 3400, 3500, 3600, 3700,
+            3650,  # Trailing stop trigger
+        ]]
+        results = compare_strategies(
+            prices=prices,
+            order_config=order_config,
+            trailing_config=TrailingStopConfig(
+                enabled=True,
+                activation_pct=Decimal("1.5"),
+                distance_pct=Decimal("0.8"),
+            ),
+        )
+        assert "fixed_tp" in results
+        assert "trailing_stop" in results
+        assert results["fixed_tp"].total_trades >= 1
+        assert results["trailing_stop"].total_trades >= 1
+
+        # On a trending price series, trailing should capture more profit
+        fixed_profit = results["fixed_tp"].trades[0].profit_pct
+        trailing_profit = results["trailing_stop"].trades[0].profit_pct
+        assert trailing_profit > fixed_profit
+
+    def test_empty_price_series(self, order_config):
+        """Empty price series returns no trades."""
+        bt = DCABacktester(order_config=order_config)
+        result = bt.run([])
+        assert result.total_trades == 0
+        assert result.win_rate == 0
+        assert result.profit_factor == 0
+
+    def test_backtest_result_all_wins(self):
+        """Profit factor with all winning trades."""
+        result = BacktestResult(trades=[
+            BacktestTrade(
+                entry_price=Decimal("100"), exit_price=Decimal("110"),
+                exit_reason="take_profit", safety_orders_filled=0,
+                profit=Decimal("10"), profit_pct=Decimal("10"),
+                total_cost=Decimal("100"),
+            ),
+        ])
+        assert result.profit_factor == Decimal("999")
+        assert result.losing_trades == 0


### PR DESCRIPTION
## Summary
- YAML-compatible `DCAStrategyConfig` with market presets (conservative/moderate/aggressive)
- Pydantic schemas for all DCA components (signal, order, risk, trailing, filter)
- `DCABacktester` simulating deal lifecycle on historical price data
- `compare_strategies()` for Fixed TP vs Trailing Stop comparison
- Integration tests: config → engine → open → monitor → close pipeline

## Test plan
- [x] Market presets: 8 tests (all presets, overrides, custom mode, completeness)
- [x] Config validation: 7 tests (defaults, consistency, component conversion)
- [x] YAML serialization: 5 tests (to/from YAML, file I/O, roundtrip all modes)
- [x] Schema validation: 8 tests (defaults, conversion, invalid inputs)
- [x] Integration: 4 tests (engine from config, full cycle, conservative limits, YAML roundtrip)
- [x] Backtester: 9 tests (fixed TP, trailing, SL, SOs, multiple deals, metrics, comparison)
- [x] All 41 tests passing

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)