### PR TITLE
feat: HybridStrategy for Grid+DCA adaptive mode switching (#167)

### DIFF
--- a/bot/orchestrator/events.py
+++ b/bot/orchestrator/events.py
@@ -54,6 +54,11 @@ class EventType(str, Enum):
     STOP_LOSS_TRIGGERED = "stop_loss_triggered"
     POSITION_LIMIT_REACHED = "position_limit_reached"
 
+    # Hybrid strategy events (v2.0)
+    GRID_BREAKOUT = "grid_breakout"
+    HYBRID_MODE_ACTIVATED = "hybrid_mode_activated"
+    HYBRID_TRANSITION = "hybrid_transition"
+
     # Price events
     PRICE_UPDATED = "price_updated"
 

--- a/bot/strategies/hybrid/__init__.py
+++ b/bot/strategies/hybrid/__init__.py
@@ -1,0 +1,38 @@
+"""Hybrid Strategy Package — v2.0 Market Regime Detection & Strategy Selection."""
+
+from bot.strategies.hybrid.hybrid_config import HybridConfig, HybridMode
+from bot.strategies.hybrid.hybrid_strategy import (
+    HybridAction,
+    HybridStrategy,
+    TransitionEvent,
+)
+from bot.strategies.hybrid.market_regime_detector import (
+    BBWidth,
+    MarketIndicators,
+    MarketRegimeDetectorV2,
+    RegimeChangeEvent,
+    RegimeConfig,
+    RegimeResult,
+    RegimeType,
+    StrategyRecommendation,
+    VolumeProfile,
+)
+
+__all__ = [
+    # Market Regime Detector
+    "MarketRegimeDetectorV2",
+    "RegimeType",
+    "StrategyRecommendation",
+    "RegimeResult",
+    "RegimeConfig",
+    "MarketIndicators",
+    "BBWidth",
+    "VolumeProfile",
+    "RegimeChangeEvent",
+    # Hybrid Strategy
+    "HybridStrategy",
+    "HybridConfig",
+    "HybridMode",
+    "HybridAction",
+    "TransitionEvent",
+]

--- a/bot/strategies/hybrid/hybrid_config.py
+++ b/bot/strategies/hybrid/hybrid_config.py
@@ -1,0 +1,84 @@
+"""
+HybridConfig — Configuration for hybrid Grid+DCA strategy mode.
+
+Defines operating modes and parameters for Grid↔DCA transitions:
+- Capital allocation between Grid and DCA
+- Breakout detection thresholds (ADX, ATR ratio)
+- Return-to-grid conditions
+- Transition cooldowns and minimum durations
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class HybridMode(str, Enum):
+    """Operating mode of the hybrid strategy."""
+
+    GRID_ONLY = "grid_only"  # Grid active, DCA standby
+    TRANSITIONING = "transitioning"  # Mid-transition between modes
+    DCA_ACTIVE = "dca_active"  # DCA active after grid breakout
+    BOTH_ACTIVE = "both_active"  # Both active (intermediate)
+
+
+@dataclass
+class HybridConfig:
+    """
+    Configuration for hybrid Grid+DCA strategy.
+
+    Capital allocation (must sum to 1.0):
+        grid_capital_pct + dca_capital_pct + reserve_pct = 1.0
+
+    Grid→DCA transition triggers when:
+        - GridRiskManager.check_trend_suitability() → DEACTIVATE
+        - ADX >= breakout_adx_threshold
+        - Time in grid mode >= min_grid_duration_seconds
+        - Cooldown since last transition elapsed
+
+    DCA→Grid return triggers when:
+        - ADX < return_adx_threshold
+        - Regime detector shows SIDEWAYS
+        - Time in DCA mode >= min_dca_duration_seconds
+        - All DCA deals closed (if require_dca_deals_closed)
+    """
+
+    # Capital allocation
+    grid_capital_pct: float = 0.6  # 60% for Grid
+    dca_capital_pct: float = 0.3  # 30% for DCA
+    reserve_pct: float = 0.1  # 10% reserve
+
+    # Grid→DCA transition thresholds
+    breakout_adx_threshold: float = 25.0  # ADX confirming trend
+    breakout_atr_multiplier: float = 2.0  # Price move > N*ATR
+    min_grid_duration_seconds: int = 300  # 5 min minimum in grid
+
+    # DCA→Grid return thresholds
+    return_adx_threshold: float = 20.0  # ADX for return to grid
+    min_dca_duration_seconds: int = 600  # 10 min minimum in DCA
+    require_dca_deals_closed: bool = True  # Wait for DCA deals to close
+
+    # Transition protection
+    transition_cooldown_seconds: int = 120  # 2 min between transitions
+    max_transition_history: int = 50  # Max history records
+
+    def validate(self) -> None:
+        """Validate configuration values."""
+        total = self.grid_capital_pct + self.dca_capital_pct + self.reserve_pct
+        if abs(total - 1.0) > 0.001:
+            raise ValueError(
+                f"Capital allocation must sum to 1.0, got {total:.3f}"
+            )
+        if self.grid_capital_pct < 0 or self.grid_capital_pct > 1:
+            raise ValueError("grid_capital_pct must be between 0 and 1")
+        if self.dca_capital_pct < 0 or self.dca_capital_pct > 1:
+            raise ValueError("dca_capital_pct must be between 0 and 1")
+        if self.reserve_pct < 0 or self.reserve_pct > 1:
+            raise ValueError("reserve_pct must be between 0 and 1")
+        if self.breakout_adx_threshold <= 0:
+            raise ValueError("breakout_adx_threshold must be positive")
+        if self.breakout_atr_multiplier <= 0:
+            raise ValueError("breakout_atr_multiplier must be positive")
+        if self.return_adx_threshold <= 0:
+            raise ValueError("return_adx_threshold must be positive")
+        if self.transition_cooldown_seconds < 0:
+            raise ValueError("transition_cooldown_seconds must be non-negative")

--- a/bot/strategies/hybrid/hybrid_strategy.py
+++ b/bot/strategies/hybrid/hybrid_strategy.py
@@ -1,0 +1,456 @@
+"""
+HybridStrategy — Coordinates Grid+DCA in a single adaptive strategy.
+
+Operates in two primary modes:
+1. GRID_ONLY: Grid trading on sideways markets (default)
+2. DCA_ACTIVE: DCA accumulation after grid breakout (trend detected)
+
+Transitions:
+- Grid→DCA: GridRiskManager detects trend (DEACTIVATE), ADX confirms
+- DCA→Grid: ADX drops, regime returns to SIDEWAYS, DCA deals closed
+
+Usage:
+    hybrid = HybridStrategy(
+        config=HybridConfig(),
+        grid_risk_manager=GridRiskManager(),
+        dca_engine=DCAEngine("BTC/USDT"),
+        regime_detector=MarketRegimeDetectorV2(),
+    )
+
+    # On each price update:
+    action = hybrid.evaluate(market_state, atr, price_move, adx)
+    if action.transition_triggered:
+        # Handle mode switch
+    if action.dca_action and action.dca_action.should_open_deal:
+        # Open DCA deal
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from bot.strategies.dca.dca_engine import DCAEngine, EngineAction
+from bot.strategies.dca.dca_signal_generator import MarketState
+from bot.strategies.grid.grid_risk_manager import (
+    GridRiskAction,
+    GridRiskManager,
+    RiskCheckResult,
+)
+from bot.strategies.hybrid.hybrid_config import HybridConfig, HybridMode
+from bot.strategies.hybrid.market_regime_detector import (
+    MarketIndicators,
+    MarketRegimeDetectorV2,
+    RegimeResult,
+    RegimeType,
+)
+from bot.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# =============================================================================
+# Data Structures
+# =============================================================================
+
+
+@dataclass
+class TransitionEvent:
+    """Records a mode transition."""
+
+    from_mode: HybridMode
+    to_mode: HybridMode
+    reason: str
+    timestamp: datetime
+    trigger_adx: float | None = None
+    trigger_atr_ratio: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "from_mode": self.from_mode.value,
+            "to_mode": self.to_mode.value,
+            "reason": self.reason,
+            "timestamp": self.timestamp.isoformat(),
+            "trigger_adx": self.trigger_adx,
+            "trigger_atr_ratio": self.trigger_atr_ratio,
+        }
+
+
+@dataclass
+class HybridAction:
+    """
+    Result of a single hybrid evaluation cycle.
+
+    Contains the current mode, any transition that occurred,
+    and actions from the active sub-strategy.
+    """
+
+    mode: HybridMode
+    transition_triggered: bool = False
+    transition_event: TransitionEvent | None = None
+
+    # Grid risk check result (when grid active)
+    grid_risk_result: RiskCheckResult | None = None
+
+    # DCA engine action (when DCA active)
+    dca_action: EngineAction | None = None
+
+    # Regime analysis (always present)
+    regime_result: RegimeResult | None = None
+
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "mode": self.mode.value,
+            "transition_triggered": self.transition_triggered,
+            "warnings": self.warnings,
+        }
+        if self.transition_event:
+            result["transition_event"] = self.transition_event.to_dict()
+        if self.grid_risk_result:
+            result["grid_risk"] = self.grid_risk_result.to_dict()
+        if self.regime_result:
+            result["regime"] = self.regime_result.to_dict()
+        return result
+
+
+# =============================================================================
+# HybridStrategy
+# =============================================================================
+
+
+class HybridStrategy:
+    """
+    Coordinates Grid and DCA strategies based on market regime.
+
+    Grid operates in sideways markets. When a breakout is detected
+    (via GridRiskManager + ADX), the strategy transitions to DCA mode.
+    When the market returns to sideways (low ADX + regime confirmation),
+    it transitions back to Grid.
+    """
+
+    def __init__(
+        self,
+        config: HybridConfig | None = None,
+        grid_risk_manager: GridRiskManager | None = None,
+        dca_engine: DCAEngine | None = None,
+        regime_detector: MarketRegimeDetectorV2 | None = None,
+    ):
+        self._config = config or HybridConfig()
+        self._config.validate()
+
+        self._grid_risk = grid_risk_manager or GridRiskManager()
+        self._dca_engine = dca_engine
+        self._regime_detector = regime_detector or MarketRegimeDetectorV2()
+
+        # State
+        self._mode = HybridMode.GRID_ONLY
+        self._mode_since = datetime.now(timezone.utc)
+        self._last_transition: datetime | None = None
+        self._transition_history: list[TransitionEvent] = []
+
+        # Statistics
+        self._total_transitions = 0
+        self._grid_to_dca_count = 0
+        self._dca_to_grid_count = 0
+
+        logger.info(
+            "HybridStrategy initialized",
+            mode=self._mode.value,
+            grid_capital_pct=self._config.grid_capital_pct,
+            dca_capital_pct=self._config.dca_capital_pct,
+        )
+
+    # =========================================================================
+    # Properties
+    # =========================================================================
+
+    @property
+    def mode(self) -> HybridMode:
+        """Current operating mode."""
+        return self._mode
+
+    @property
+    def mode_since(self) -> datetime:
+        """When current mode started."""
+        return self._mode_since
+
+    @property
+    def transition_history(self) -> list[TransitionEvent]:
+        """Copy of transition history (most recent first)."""
+        return self._transition_history.copy()
+
+    @property
+    def config(self) -> HybridConfig:
+        return self._config
+
+    # =========================================================================
+    # Main Evaluation
+    # =========================================================================
+
+    def evaluate(
+        self,
+        market_state: MarketState,
+        atr: Decimal = Decimal("0"),
+        price_move: Decimal = Decimal("0"),
+        adx: float | None = None,
+        regime_result: RegimeResult | None = None,
+    ) -> HybridAction:
+        """
+        Evaluate market conditions and determine hybrid action.
+
+        Called on each price update. Checks for mode transitions,
+        then delegates to the active sub-strategy.
+
+        Args:
+            market_state: Current market conditions (for DCA engine).
+            atr: Current ATR value (for grid risk check).
+            price_move: Absolute price change over ATR period.
+            adx: ADX value if available.
+            regime_result: Pre-computed regime result (optional).
+
+        Returns:
+            HybridAction with mode, transitions, and sub-strategy actions.
+        """
+        action = HybridAction(mode=self._mode)
+
+        # Compute regime if not provided
+        if regime_result is None and adx is not None:
+            indicators = MarketIndicators(
+                current_price=market_state.current_price,
+                adx=adx,
+                ema_fast=market_state.ema_fast,
+                ema_slow=market_state.ema_slow,
+                rsi=market_state.rsi if hasattr(market_state, "rsi") else None,
+                atr=atr if atr > 0 else None,
+            )
+            regime_result = self._regime_detector.evaluate(indicators)
+        action.regime_result = regime_result
+
+        # Check for transitions
+        if self._mode == HybridMode.GRID_ONLY:
+            self._evaluate_grid_mode(action, atr, price_move, adx, regime_result)
+        elif self._mode == HybridMode.DCA_ACTIVE:
+            self._evaluate_dca_mode(action, market_state, adx, regime_result)
+
+        return action
+
+    # =========================================================================
+    # Grid Mode Evaluation
+    # =========================================================================
+
+    def _evaluate_grid_mode(
+        self,
+        action: HybridAction,
+        atr: Decimal,
+        price_move: Decimal,
+        adx: float | None,
+        regime_result: RegimeResult | None,
+    ) -> None:
+        """Evaluate while in GRID_ONLY mode."""
+        # Run grid risk check
+        risk_result = self._grid_risk.check_trend_suitability(
+            atr=atr, price_move=price_move, adx=adx
+        )
+        action.grid_risk_result = risk_result
+
+        # Check if breakout should trigger Grid→DCA
+        if risk_result.action == GridRiskAction.DEACTIVATE:
+            if self._can_transition_to_dca(adx):
+                event = self._execute_transition(
+                    to_mode=HybridMode.DCA_ACTIVE,
+                    reason=f"Grid breakout detected: {'; '.join(risk_result.reasons)}",
+                    adx=adx,
+                    atr_ratio=float(price_move / atr) if atr > 0 else None,
+                )
+                action.transition_triggered = True
+                action.transition_event = event
+                action.mode = self._mode
+
+                logger.info(
+                    "hybrid_grid_to_dca",
+                    reasons=risk_result.reasons,
+                    adx=adx,
+                )
+            else:
+                action.warnings.append("Grid breakout detected but transition blocked")
+
+    # =========================================================================
+    # DCA Mode Evaluation
+    # =========================================================================
+
+    def _evaluate_dca_mode(
+        self,
+        action: HybridAction,
+        market_state: MarketState,
+        adx: float | None,
+        regime_result: RegimeResult | None,
+    ) -> None:
+        """Evaluate while in DCA_ACTIVE mode."""
+        # Run DCA engine if available
+        if self._dca_engine is not None:
+            dca_action = self._dca_engine.on_price_update(market_state)
+            action.dca_action = dca_action
+
+        # Check if should return to Grid
+        if self._can_transition_to_grid(adx, regime_result):
+            event = self._execute_transition(
+                to_mode=HybridMode.GRID_ONLY,
+                reason="Market returned to sideways, ADX below threshold",
+                adx=adx,
+            )
+            action.transition_triggered = True
+            action.transition_event = event
+            action.mode = self._mode
+
+            logger.info(
+                "hybrid_dca_to_grid",
+                adx=adx,
+                regime=regime_result.regime.value if regime_result else None,
+            )
+
+    # =========================================================================
+    # Transition Checks
+    # =========================================================================
+
+    def _can_transition_to_dca(self, adx: float | None) -> bool:
+        """Check if Grid→DCA transition is allowed."""
+        now = datetime.now(timezone.utc)
+
+        # Check cooldown
+        if self._last_transition is not None:
+            elapsed = (now - self._last_transition).total_seconds()
+            if elapsed < self._config.transition_cooldown_seconds:
+                return False
+
+        # Check minimum grid duration
+        mode_elapsed = (now - self._mode_since).total_seconds()
+        if mode_elapsed < self._config.min_grid_duration_seconds:
+            return False
+
+        # ADX must confirm trend
+        if adx is not None and adx < self._config.breakout_adx_threshold:
+            return False
+
+        return True
+
+    def _can_transition_to_grid(
+        self, adx: float | None, regime_result: RegimeResult | None
+    ) -> bool:
+        """Check if DCA→Grid transition is allowed."""
+        now = datetime.now(timezone.utc)
+
+        # Check cooldown
+        if self._last_transition is not None:
+            elapsed = (now - self._last_transition).total_seconds()
+            if elapsed < self._config.transition_cooldown_seconds:
+                return False
+
+        # Check minimum DCA duration
+        mode_elapsed = (now - self._mode_since).total_seconds()
+        if mode_elapsed < self._config.min_dca_duration_seconds:
+            return False
+
+        # ADX must be below return threshold
+        if adx is not None and adx >= self._config.return_adx_threshold:
+            return False
+
+        # Regime should be sideways
+        if regime_result is not None and regime_result.regime != RegimeType.SIDEWAYS:
+            return False
+
+        # Check if DCA deals are closed (if required)
+        if self._config.require_dca_deals_closed and self._dca_engine is not None:
+            active_deals = self._dca_engine.position_manager.get_active_deals()
+            if len(active_deals) > 0:
+                return False
+
+        return True
+
+    # =========================================================================
+    # Transition Execution
+    # =========================================================================
+
+    def _execute_transition(
+        self,
+        to_mode: HybridMode,
+        reason: str,
+        adx: float | None = None,
+        atr_ratio: float | None = None,
+    ) -> TransitionEvent:
+        """Execute a mode transition."""
+        now = datetime.now(timezone.utc)
+        from_mode = self._mode
+
+        event = TransitionEvent(
+            from_mode=from_mode,
+            to_mode=to_mode,
+            reason=reason,
+            timestamp=now,
+            trigger_adx=adx,
+            trigger_atr_ratio=atr_ratio,
+        )
+
+        # Update state
+        self._mode = to_mode
+        self._mode_since = now
+        self._last_transition = now
+        self._total_transitions += 1
+
+        if from_mode == HybridMode.GRID_ONLY and to_mode == HybridMode.DCA_ACTIVE:
+            self._grid_to_dca_count += 1
+        elif from_mode == HybridMode.DCA_ACTIVE and to_mode == HybridMode.GRID_ONLY:
+            self._dca_to_grid_count += 1
+
+        # Record history
+        self._transition_history.insert(0, event)
+        if len(self._transition_history) > self._config.max_transition_history:
+            self._transition_history = self._transition_history[
+                : self._config.max_transition_history
+            ]
+
+        logger.info(
+            "hybrid_transition",
+            from_mode=from_mode.value,
+            to_mode=to_mode.value,
+            reason=reason,
+            adx=adx,
+        )
+
+        return event
+
+    # =========================================================================
+    # Status & Statistics
+    # =========================================================================
+
+    def get_status(self) -> dict[str, Any]:
+        """Get current hybrid strategy status."""
+        now = datetime.now(timezone.utc)
+        mode_duration = (now - self._mode_since).total_seconds()
+
+        return {
+            "mode": self._mode.value,
+            "mode_since": self._mode_since.isoformat(),
+            "mode_duration_seconds": round(mode_duration, 1),
+            "last_transition": (
+                self._last_transition.isoformat() if self._last_transition else None
+            ),
+            "config": {
+                "grid_capital_pct": self._config.grid_capital_pct,
+                "dca_capital_pct": self._config.dca_capital_pct,
+                "breakout_adx_threshold": self._config.breakout_adx_threshold,
+                "return_adx_threshold": self._config.return_adx_threshold,
+                "transition_cooldown_seconds": self._config.transition_cooldown_seconds,
+            },
+        }
+
+    def get_statistics(self) -> dict[str, Any]:
+        """Get transition statistics."""
+        return {
+            "total_transitions": self._total_transitions,
+            "grid_to_dca_count": self._grid_to_dca_count,
+            "dca_to_grid_count": self._dca_to_grid_count,
+            "history_count": len(self._transition_history),
+            "current_mode": self._mode.value,
+        }

--- a/tests/strategies/hybrid/test_hybrid_strategy.py
+++ b/tests/strategies/hybrid/test_hybrid_strategy.py
@@ -1,0 +1,639 @@
+"""Tests for HybridStrategy — Grid+DCA hybrid mode."""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from bot.strategies.dca.dca_engine import DCAEngine
+from bot.strategies.dca.dca_signal_generator import MarketState
+from bot.strategies.grid.grid_risk_manager import (
+    GridRiskAction,
+    GridRiskManager,
+    RiskCheckResult,
+)
+from bot.strategies.hybrid.hybrid_config import HybridConfig, HybridMode
+from bot.strategies.hybrid.hybrid_strategy import (
+    HybridAction,
+    HybridStrategy,
+    TransitionEvent,
+)
+from bot.strategies.hybrid.market_regime_detector import (
+    MarketRegimeDetectorV2,
+    RegimeResult,
+    RegimeType,
+    StrategyRecommendation,
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_market_state(price: float = 3000.0) -> MarketState:
+    """Create a MarketState for testing."""
+    return MarketState(
+        current_price=Decimal(str(price)),
+        ema_fast=Decimal(str(price * 1.01)),
+        ema_slow=Decimal(str(price * 0.99)),
+        adx=20.0,
+        rsi=50.0,
+        current_time=datetime.now(timezone.utc),
+    )
+
+
+def _make_regime_result(
+    regime: RegimeType = RegimeType.SIDEWAYS,
+    strategy: StrategyRecommendation = StrategyRecommendation.GRID,
+    confidence: float = 0.8,
+) -> RegimeResult:
+    """Create a RegimeResult for testing."""
+    return RegimeResult(
+        regime=regime,
+        strategy=strategy,
+        confidence=confidence,
+    )
+
+
+def _make_dca_engine() -> DCAEngine:
+    """Create a DCA engine for testing."""
+    return DCAEngine(symbol="BTC/USDT")
+
+
+def _make_hybrid(
+    transition_cooldown: int = 0,
+    min_grid_duration: int = 0,
+    min_dca_duration: int = 0,
+    breakout_adx: float = 25.0,
+    return_adx: float = 20.0,
+    require_deals_closed: bool = True,
+) -> HybridStrategy:
+    """Create a HybridStrategy with test-friendly defaults."""
+    config = HybridConfig(
+        transition_cooldown_seconds=transition_cooldown,
+        min_grid_duration_seconds=min_grid_duration,
+        min_dca_duration_seconds=min_dca_duration,
+        breakout_adx_threshold=breakout_adx,
+        return_adx_threshold=return_adx,
+        require_dca_deals_closed=require_deals_closed,
+    )
+    return HybridStrategy(
+        config=config,
+        grid_risk_manager=GridRiskManager(),
+        dca_engine=_make_dca_engine(),
+        regime_detector=MarketRegimeDetectorV2(),
+    )
+
+
+# =============================================================================
+# TestHybridConfig
+# =============================================================================
+
+
+class TestHybridConfig:
+    """Tests for HybridConfig."""
+
+    def test_default_config(self):
+        config = HybridConfig()
+        total = config.grid_capital_pct + config.dca_capital_pct + config.reserve_pct
+        assert abs(total - 1.0) < 0.001
+        assert config.breakout_adx_threshold == 25.0
+        assert config.return_adx_threshold == 20.0
+        assert config.transition_cooldown_seconds == 120
+
+    def test_custom_config(self):
+        config = HybridConfig(
+            grid_capital_pct=0.5,
+            dca_capital_pct=0.4,
+            reserve_pct=0.1,
+            breakout_adx_threshold=30.0,
+        )
+        config.validate()
+        assert config.grid_capital_pct == 0.5
+        assert config.breakout_adx_threshold == 30.0
+
+    def test_config_validation_capital_sum(self):
+        config = HybridConfig(
+            grid_capital_pct=0.5,
+            dca_capital_pct=0.3,
+            reserve_pct=0.1,
+        )
+        with pytest.raises(ValueError, match="sum to 1.0"):
+            config.validate()
+
+    def test_config_validation_negative(self):
+        config = HybridConfig(
+            grid_capital_pct=-0.1,
+            dca_capital_pct=1.0,
+            reserve_pct=0.1,
+        )
+        with pytest.raises(ValueError, match="grid_capital_pct"):
+            config.validate()
+
+
+# =============================================================================
+# TestHybridStrategy
+# =============================================================================
+
+
+class TestHybridStrategy:
+    """Tests for HybridStrategy initialization and basic evaluation."""
+
+    def test_init_starts_in_grid_mode(self):
+        hybrid = _make_hybrid()
+        assert hybrid.mode == HybridMode.GRID_ONLY
+        assert hybrid.mode_since is not None
+        assert len(hybrid.transition_history) == 0
+
+    def test_evaluate_in_grid_mode_returns_grid_risk(self):
+        hybrid = _make_hybrid()
+        state = _make_market_state()
+        regime = _make_regime_result()
+
+        action = hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("30"),  # Below threshold
+            adx=15.0,  # Low ADX
+            regime_result=regime,
+        )
+
+        assert action.mode == HybridMode.GRID_ONLY
+        assert action.grid_risk_result is not None
+        assert action.dca_action is None
+        assert not action.transition_triggered
+
+    def test_evaluate_in_dca_mode_returns_dca_action(self):
+        hybrid = _make_hybrid()
+        # Force DCA mode
+        hybrid._mode = HybridMode.DCA_ACTIVE
+        hybrid._mode_since = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        state = _make_market_state()
+        regime = _make_regime_result(
+            regime=RegimeType.DOWNTREND,
+            strategy=StrategyRecommendation.DCA,
+        )
+
+        action = hybrid.evaluate(
+            state, atr=Decimal("50"), price_move=Decimal("100"),
+            adx=30.0, regime_result=regime,
+        )
+
+        assert action.mode == HybridMode.DCA_ACTIVE
+        assert action.dca_action is not None
+
+    def test_get_status(self):
+        hybrid = _make_hybrid()
+        status = hybrid.get_status()
+
+        assert status["mode"] == "grid_only"
+        assert "mode_since" in status
+        assert "mode_duration_seconds" in status
+        assert status["last_transition"] is None
+        assert "config" in status
+
+    def test_get_statistics(self):
+        hybrid = _make_hybrid()
+        stats = hybrid.get_statistics()
+
+        assert stats["total_transitions"] == 0
+        assert stats["grid_to_dca_count"] == 0
+        assert stats["dca_to_grid_count"] == 0
+        assert stats["current_mode"] == "grid_only"
+
+
+# =============================================================================
+# TestGridToDcaTransition
+# =============================================================================
+
+
+class TestGridToDcaTransition:
+    """Tests for Grid→DCA transition."""
+
+    def test_breakout_triggers_transition(self):
+        hybrid = _make_hybrid()
+        state = _make_market_state()
+
+        # Large price move + high ADX → DEACTIVATE → transition
+        action = hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("120"),  # 2.4x ATR > 2.0 threshold
+            adx=30.0,  # > 25.0 threshold
+            regime_result=_make_regime_result(
+                regime=RegimeType.DOWNTREND,
+                strategy=StrategyRecommendation.DCA,
+            ),
+        )
+
+        assert action.transition_triggered
+        assert action.mode == HybridMode.DCA_ACTIVE
+        assert action.transition_event is not None
+        assert action.transition_event.from_mode == HybridMode.GRID_ONLY
+        assert action.transition_event.to_mode == HybridMode.DCA_ACTIVE
+        assert hybrid.mode == HybridMode.DCA_ACTIVE
+
+    def test_breakout_blocked_by_cooldown(self):
+        hybrid = _make_hybrid(transition_cooldown=300)
+        # Simulate recent transition
+        hybrid._last_transition = datetime.now(timezone.utc)
+
+        state = _make_market_state()
+        action = hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("120"),
+            adx=30.0,
+            regime_result=_make_regime_result(),
+        )
+
+        assert not action.transition_triggered
+        assert hybrid.mode == HybridMode.GRID_ONLY
+
+    def test_breakout_blocked_by_min_duration(self):
+        hybrid = _make_hybrid(min_grid_duration=300)
+        # Mode just started (recently)
+        hybrid._mode_since = datetime.now(timezone.utc)
+
+        state = _make_market_state()
+        action = hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("120"),
+            adx=30.0,
+            regime_result=_make_regime_result(),
+        )
+
+        assert not action.transition_triggered
+        assert hybrid.mode == HybridMode.GRID_ONLY
+
+    def test_breakout_requires_adx_confirmation(self):
+        hybrid = _make_hybrid(breakout_adx=25.0)
+        state = _make_market_state()
+
+        # Large price move but low ADX
+        action = hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("120"),  # ATR ratio triggers DEACTIVATE
+            adx=15.0,  # Below breakout threshold
+            regime_result=_make_regime_result(),
+        )
+
+        assert not action.transition_triggered
+        assert hybrid.mode == HybridMode.GRID_ONLY
+
+    def test_transition_event_recorded(self):
+        hybrid = _make_hybrid()
+        state = _make_market_state()
+
+        hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("120"),
+            adx=30.0,
+            regime_result=_make_regime_result(),
+        )
+
+        assert len(hybrid.transition_history) == 1
+        event = hybrid.transition_history[0]
+        assert event.from_mode == HybridMode.GRID_ONLY
+        assert event.to_mode == HybridMode.DCA_ACTIVE
+        assert event.trigger_adx == 30.0
+
+    def test_mode_changes_to_dca_active(self):
+        hybrid = _make_hybrid()
+        state = _make_market_state()
+
+        assert hybrid.mode == HybridMode.GRID_ONLY
+        hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("120"),
+            adx=30.0,
+            regime_result=_make_regime_result(),
+        )
+        assert hybrid.mode == HybridMode.DCA_ACTIVE
+
+    def test_grid_not_active_after_transition(self):
+        hybrid = _make_hybrid()
+        state = _make_market_state()
+
+        # Trigger Grid→DCA
+        hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("120"),
+            adx=30.0,
+            regime_result=_make_regime_result(),
+        )
+
+        # Next evaluation in DCA mode should NOT have grid_risk_result
+        action = hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("30"),
+            adx=30.0,
+            regime_result=_make_regime_result(
+                regime=RegimeType.DOWNTREND,
+                strategy=StrategyRecommendation.DCA,
+            ),
+        )
+        assert action.grid_risk_result is None
+        assert action.dca_action is not None
+
+
+# =============================================================================
+# TestDcaToGridTransition
+# =============================================================================
+
+
+class TestDcaToGridTransition:
+    """Tests for DCA→Grid transition."""
+
+    def test_return_when_sideways_and_low_adx(self):
+        hybrid = _make_hybrid(require_deals_closed=False)
+        # Force into DCA mode with enough time elapsed
+        hybrid._mode = HybridMode.DCA_ACTIVE
+        hybrid._mode_since = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        state = _make_market_state()
+        regime = _make_regime_result(
+            regime=RegimeType.SIDEWAYS,
+            strategy=StrategyRecommendation.GRID,
+        )
+
+        action = hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("30"),
+            adx=15.0,  # Below return threshold (20.0)
+            regime_result=regime,
+        )
+
+        assert action.transition_triggered
+        assert hybrid.mode == HybridMode.GRID_ONLY
+
+    def test_return_blocked_by_open_deals(self):
+        hybrid = _make_hybrid(require_deals_closed=True)
+        hybrid._mode = HybridMode.DCA_ACTIVE
+        hybrid._mode_since = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        # Open a DCA deal
+        dca = hybrid._dca_engine
+        dca.position_manager.open_deal(entry_price=Decimal("3000"))
+
+        state = _make_market_state()
+        regime = _make_regime_result(regime=RegimeType.SIDEWAYS)
+
+        action = hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("30"),
+            adx=15.0,
+            regime_result=regime,
+        )
+
+        assert not action.transition_triggered
+        assert hybrid.mode == HybridMode.DCA_ACTIVE
+
+    def test_return_blocked_by_min_duration(self):
+        hybrid = _make_hybrid(min_dca_duration=600)
+        hybrid._mode = HybridMode.DCA_ACTIVE
+        hybrid._mode_since = datetime.now(timezone.utc)  # Just started
+
+        state = _make_market_state()
+        regime = _make_regime_result(regime=RegimeType.SIDEWAYS)
+
+        action = hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("30"),
+            adx=15.0,
+            regime_result=regime,
+        )
+
+        assert not action.transition_triggered
+        assert hybrid.mode == HybridMode.DCA_ACTIVE
+
+    def test_return_blocked_by_high_adx(self):
+        hybrid = _make_hybrid(return_adx=20.0, require_deals_closed=False)
+        hybrid._mode = HybridMode.DCA_ACTIVE
+        hybrid._mode_since = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        state = _make_market_state()
+        regime = _make_regime_result(regime=RegimeType.SIDEWAYS)
+
+        action = hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("30"),
+            adx=25.0,  # Above return threshold
+            regime_result=regime,
+        )
+
+        assert not action.transition_triggered
+        assert hybrid.mode == HybridMode.DCA_ACTIVE
+
+    def test_return_blocked_by_wrong_regime(self):
+        hybrid = _make_hybrid(require_deals_closed=False)
+        hybrid._mode = HybridMode.DCA_ACTIVE
+        hybrid._mode_since = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        state = _make_market_state()
+        regime = _make_regime_result(
+            regime=RegimeType.DOWNTREND,  # Not SIDEWAYS
+            strategy=StrategyRecommendation.DCA,
+        )
+
+        action = hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("30"),
+            adx=15.0,  # Low enough, but wrong regime
+            regime_result=regime,
+        )
+
+        assert not action.transition_triggered
+        assert hybrid.mode == HybridMode.DCA_ACTIVE
+
+    def test_full_cycle_grid_dca_grid(self):
+        hybrid = _make_hybrid(require_deals_closed=False)
+        state = _make_market_state()
+
+        # Step 1: Start in Grid
+        assert hybrid.mode == HybridMode.GRID_ONLY
+
+        # Step 2: Breakout → DCA
+        hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("120"),
+            adx=30.0,
+            regime_result=_make_regime_result(
+                regime=RegimeType.DOWNTREND,
+                strategy=StrategyRecommendation.DCA,
+            ),
+        )
+        assert hybrid.mode == HybridMode.DCA_ACTIVE
+
+        # Step 3: Set time to allow return
+        hybrid._mode_since = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        # Step 4: Return → Grid
+        hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("20"),
+            adx=15.0,
+            regime_result=_make_regime_result(
+                regime=RegimeType.SIDEWAYS,
+                strategy=StrategyRecommendation.GRID,
+            ),
+        )
+        assert hybrid.mode == HybridMode.GRID_ONLY
+
+        # Step 5: Check history
+        stats = hybrid.get_statistics()
+        assert stats["total_transitions"] == 2
+        assert stats["grid_to_dca_count"] == 1
+        assert stats["dca_to_grid_count"] == 1
+
+    def test_transition_history_tracking(self):
+        hybrid = _make_hybrid(require_deals_closed=False)
+        state = _make_market_state()
+
+        # Transition 1: Grid→DCA
+        hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("120"),
+            adx=30.0,
+            regime_result=_make_regime_result(),
+        )
+
+        assert len(hybrid.transition_history) == 1
+        assert hybrid.transition_history[0].to_mode == HybridMode.DCA_ACTIVE
+
+
+# =============================================================================
+# TestHybridEdgeCases
+# =============================================================================
+
+
+class TestHybridEdgeCases:
+    """Tests for edge cases and safety mechanisms."""
+
+    def test_rapid_oscillation_prevented(self):
+        hybrid = _make_hybrid(transition_cooldown=300, require_deals_closed=False)
+        state = _make_market_state()
+
+        # Trigger Grid→DCA
+        hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("120"),
+            adx=30.0,
+            regime_result=_make_regime_result(),
+        )
+        assert hybrid.mode == HybridMode.DCA_ACTIVE
+
+        # Try immediate return → blocked by cooldown
+        hybrid._mode_since = datetime.now(timezone.utc) - timedelta(hours=1)
+        action = hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("20"),
+            adx=15.0,
+            regime_result=_make_regime_result(regime=RegimeType.SIDEWAYS),
+        )
+        assert not action.transition_triggered
+        assert hybrid.mode == HybridMode.DCA_ACTIVE
+
+    def test_evaluate_with_none_adx(self):
+        hybrid = _make_hybrid()
+        state = _make_market_state()
+
+        # No ADX → grid risk check still runs (no ADX-based deactivation)
+        action = hybrid.evaluate(
+            state,
+            atr=Decimal("50"),
+            price_move=Decimal("30"),
+            adx=None,
+            regime_result=_make_regime_result(),
+        )
+
+        assert action.mode == HybridMode.GRID_ONLY
+        assert not action.transition_triggered
+
+    def test_transition_history_max_size(self):
+        config = HybridConfig(
+            transition_cooldown_seconds=0,
+            min_grid_duration_seconds=0,
+            min_dca_duration_seconds=0,
+            max_transition_history=3,
+            require_dca_deals_closed=False,
+        )
+        hybrid = HybridStrategy(
+            config=config,
+            grid_risk_manager=GridRiskManager(),
+            dca_engine=_make_dca_engine(),
+            regime_detector=MarketRegimeDetectorV2(),
+        )
+        state = _make_market_state()
+
+        for i in range(5):
+            if hybrid.mode == HybridMode.GRID_ONLY:
+                hybrid.evaluate(
+                    state,
+                    atr=Decimal("50"),
+                    price_move=Decimal("120"),
+                    adx=30.0,
+                    regime_result=_make_regime_result(
+                        regime=RegimeType.DOWNTREND,
+                        strategy=StrategyRecommendation.DCA,
+                    ),
+                )
+            else:
+                hybrid._mode_since = datetime.now(timezone.utc) - timedelta(hours=1)
+                hybrid.evaluate(
+                    state,
+                    atr=Decimal("50"),
+                    price_move=Decimal("20"),
+                    adx=15.0,
+                    regime_result=_make_regime_result(
+                        regime=RegimeType.SIDEWAYS,
+                        strategy=StrategyRecommendation.GRID,
+                    ),
+                )
+
+        assert len(hybrid.transition_history) <= 3
+
+    def test_transition_event_serialization(self):
+        event = TransitionEvent(
+            from_mode=HybridMode.GRID_ONLY,
+            to_mode=HybridMode.DCA_ACTIVE,
+            reason="Test breakout",
+            timestamp=datetime.now(timezone.utc),
+            trigger_adx=30.0,
+            trigger_atr_ratio=2.4,
+        )
+        d = event.to_dict()
+
+        assert d["from_mode"] == "grid_only"
+        assert d["to_mode"] == "dca_active"
+        assert d["reason"] == "Test breakout"
+        assert d["trigger_adx"] == 30.0
+
+    def test_hybrid_action_serialization(self):
+        action = HybridAction(
+            mode=HybridMode.GRID_ONLY,
+            warnings=["test warning"],
+        )
+        d = action.to_dict()
+
+        assert d["mode"] == "grid_only"
+        assert d["transition_triggered"] is False
+        assert "test warning" in d["warnings"]


### PR DESCRIPTION
## Summary
- **HybridStrategy** coordinates Grid and DCA strategies based on market regime
- Grid operates in sideways markets; transitions to DCA on breakout detection (GridRiskManager DEACTIVATE + ADX confirmation)
- Returns to Grid when ADX drops, regime returns to SIDEWAYS, and DCA deals are closed
- HybridConfig: capital allocation (60% Grid / 30% DCA / 10% reserve), ADX thresholds, cooldowns, min durations
- New events: `GRID_BREAKOUT`, `HYBRID_MODE_ACTIVATED`, `HYBRID_TRANSITION`

Closes #167

## Test plan
- [x] 28 tests across 5 test classes, all passing
- [x] Config validation: capital sum, custom params, invalid values
- [x] Grid mode evaluation: risk result returned, no DCA action
- [x] DCA mode evaluation: DCA engine action returned
- [x] Grid→DCA transitions: breakout trigger, cooldown blocking, min duration, ADX confirmation
- [x] DCA→Grid transitions: sideways+low ADX return, open deals blocking, min duration, high ADX, wrong regime
- [x] Full cycle: Grid→DCA→Grid with statistics tracking
- [x] Edge cases: rapid oscillation prevention, None ADX handling, history max size
- [x] Serialization: TransitionEvent.to_dict(), HybridAction.to_dict()

🤖 Generated with [Claude Code](https://claude.com/claude-code)