### PR TITLE
feat: Complete Docker monitoring stack setup (#168)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# Version control
+.git
+.github
+.gitignore
+
+# Python cache
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.mypy_cache
+.ruff_cache
+
+# Environment
+.env
+.env.local
+.venv
+venv
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# Documentation (not needed in container)
+*.md
+docs/
+screenshots/
+
+# Development files
+experiments/
+ci-logs/
+*.xlsx
+*.png
+*.jpg
+
+# Testing (dev only)
+tests/
+pytest.ini
+.coveragerc
+
+# Build artifacts
+dist/
+build/
+*.egg-info

--- a/Dockerfile.exporter
+++ b/Dockerfile.exporter
@@ -1,0 +1,22 @@
+FROM python:3.11-slim AS runtime
+
+WORKDIR /app
+
+# Install only required dependencies
+RUN pip install --no-cache-dir aiohttp>=3.9.0 structlog>=24.1.0
+
+# Copy monitoring module and utils
+COPY bot/monitoring/ bot/monitoring/
+COPY bot/utils/logger.py bot/utils/logger.py
+COPY bot/__init__.py bot/__init__.py
+COPY bot/utils/__init__.py bot/utils/__init__.py
+
+ENV PYTHONPATH=/app
+ENV METRICS_PORT=9100
+
+EXPOSE 9100
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:9100/health')" || exit 1
+
+CMD ["python", "-m", "bot.monitoring.metrics_exporter"]

--- a/bot/monitoring/__init__.py
+++ b/bot/monitoring/__init__.py
@@ -1,0 +1,5 @@
+"""Bot monitoring module — Prometheus metrics exporter."""
+
+from bot.monitoring.metrics_exporter import MetricsExporter
+
+__all__ = ["MetricsExporter"]

--- a/bot/monitoring/metrics_exporter.py
+++ b/bot/monitoring/metrics_exporter.py
@@ -1,0 +1,252 @@
+"""
+MetricsExporter — Prometheus-compatible metrics HTTP endpoint.
+
+Exposes bot trading metrics in Prometheus text format on /metrics.
+No external prometheus_client dependency — uses plain text format.
+
+Usage:
+    exporter = MetricsExporter(port=9100)
+    exporter.set_metric("traderagent_portfolio_value", 10000.0)
+    exporter.increment("traderagent_total_trades")
+    await exporter.start()
+    # ...
+    await exporter.stop()
+"""
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from aiohttp import web
+
+from bot.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class MetricValue:
+    """Single metric with optional labels."""
+
+    value: float
+    labels: dict[str, str] = field(default_factory=dict)
+    help_text: str = ""
+    metric_type: str = "gauge"  # gauge, counter
+
+
+# Standard metric definitions
+METRIC_DEFINITIONS: dict[str, tuple[str, str]] = {
+    "traderagent_portfolio_value": ("gauge", "Current portfolio value in quote currency"),
+    "traderagent_active_deals": ("gauge", "Number of currently active deals"),
+    "traderagent_total_trades": ("counter", "Total number of executed trades"),
+    "traderagent_pnl_total": ("gauge", "Total realized PnL"),
+    "traderagent_pnl_unrealized": ("gauge", "Total unrealized PnL"),
+    "traderagent_api_latency_seconds": ("gauge", "Last API call latency in seconds"),
+    "traderagent_bot_uptime_seconds": ("gauge", "Bot uptime in seconds"),
+    "traderagent_strategy_active": ("gauge", "Whether strategy is active (1=yes, 0=no)"),
+    "traderagent_health_status": ("gauge", "Bot health status (1=healthy, 0=unhealthy)"),
+    "traderagent_grid_open_orders": ("gauge", "Number of open grid orders"),
+    "traderagent_dca_safety_orders_filled": ("counter", "Total safety orders filled"),
+    "traderagent_regime_changes_total": ("counter", "Total market regime changes"),
+}
+
+
+class MetricsExporter:
+    """
+    HTTP server that exposes Prometheus-format metrics on /metrics.
+
+    Thread-safe metric updates via simple dict operations.
+    Supports labeled metrics (e.g., per-strategy, per-pair).
+    """
+
+    def __init__(self, port: int = 9100, host: str = "0.0.0.0") -> None:
+        self._port = port
+        self._host = host
+        self._metrics: dict[str, list[MetricValue]] = {}
+        self._app: web.Application | None = None
+        self._runner: web.AppRunner | None = None
+        self._start_time = time.time()
+
+    @property
+    def port(self) -> int:
+        return self._port
+
+    @property
+    def metrics(self) -> dict[str, list[MetricValue]]:
+        """Copy of current metrics."""
+        return {k: list(v) for k, v in self._metrics.items()}
+
+    # =========================================================================
+    # Metric Operations
+    # =========================================================================
+
+    def set_metric(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """
+        Set a metric value, replacing any existing value with matching labels.
+
+        Args:
+            name: Metric name (e.g., "traderagent_portfolio_value").
+            value: Numeric value.
+            labels: Optional label dict (e.g., {"strategy": "grid", "pair": "BTCUSDT"}).
+        """
+        labels = labels or {}
+        metric = MetricValue(value=value, labels=labels)
+
+        # Set type/help from definitions
+        if name in METRIC_DEFINITIONS:
+            metric.metric_type, metric.help_text = METRIC_DEFINITIONS[name]
+
+        if name not in self._metrics:
+            self._metrics[name] = [metric]
+            return
+
+        # Replace existing metric with same labels
+        for i, existing in enumerate(self._metrics[name]):
+            if existing.labels == labels:
+                self._metrics[name][i] = metric
+                return
+
+        # New label combination
+        self._metrics[name].append(metric)
+
+    def increment(
+        self,
+        name: str,
+        amount: float = 1.0,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """
+        Increment a counter metric.
+
+        Args:
+            name: Metric name.
+            amount: Amount to add (default 1.0).
+            labels: Optional labels.
+        """
+        labels = labels or {}
+
+        if name in self._metrics:
+            for metric in self._metrics[name]:
+                if metric.labels == labels:
+                    metric.value += amount
+                    return
+
+        # First time — initialize
+        self.set_metric(name, amount, labels)
+
+    def remove_metric(self, name: str) -> None:
+        """Remove all values for a metric."""
+        self._metrics.pop(name, None)
+
+    def clear(self) -> None:
+        """Clear all metrics."""
+        self._metrics.clear()
+
+    # =========================================================================
+    # Prometheus Format
+    # =========================================================================
+
+    def format_metrics(self) -> str:
+        """
+        Format all metrics in Prometheus text exposition format.
+
+        Returns:
+            String in Prometheus format.
+        """
+        lines: list[str] = []
+
+        # Auto-add uptime
+        uptime = time.time() - self._start_time
+        self.set_metric("traderagent_bot_uptime_seconds", uptime)
+
+        seen_headers: set[str] = set()
+
+        for name, values in sorted(self._metrics.items()):
+            # HELP and TYPE headers (once per metric name)
+            if name not in seen_headers:
+                seen_headers.add(name)
+                help_text = ""
+                metric_type = "gauge"
+                if values:
+                    help_text = values[0].help_text
+                    metric_type = values[0].metric_type
+                if name in METRIC_DEFINITIONS:
+                    metric_type, help_text = METRIC_DEFINITIONS[name]
+
+                if help_text:
+                    lines.append(f"# HELP {name} {help_text}")
+                lines.append(f"# TYPE {name} {metric_type}")
+
+            # Metric values
+            for mv in values:
+                if mv.labels:
+                    label_str = ",".join(
+                        f'{k}="{v}"' for k, v in sorted(mv.labels.items())
+                    )
+                    lines.append(f"{name}{{{label_str}}} {mv.value}")
+                else:
+                    lines.append(f"{name} {mv.value}")
+
+        return "\n".join(lines) + "\n"
+
+    # =========================================================================
+    # HTTP Server
+    # =========================================================================
+
+    async def start(self) -> None:
+        """Start the HTTP metrics server."""
+        self._app = web.Application()
+        self._app.router.add_get("/metrics", self._handle_metrics)
+        self._app.router.add_get("/health", self._handle_health)
+
+        self._runner = web.AppRunner(self._app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self._host, self._port)
+        await site.start()
+
+        logger.info(
+            "metrics_exporter_started",
+            host=self._host,
+            port=self._port,
+        )
+
+    async def stop(self) -> None:
+        """Stop the HTTP metrics server."""
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+            self._app = None
+            logger.info("metrics_exporter_stopped")
+
+    async def _handle_metrics(self, request: web.Request) -> web.Response:
+        """Handle GET /metrics — return Prometheus format."""
+        body = self.format_metrics()
+        return web.Response(
+            text=body,
+            content_type="text/plain",
+            charset="utf-8",
+        )
+
+    async def _handle_health(self, request: web.Request) -> web.Response:
+        """Handle GET /health — simple health check."""
+        return web.Response(text="ok", content_type="text/plain")
+
+    # =========================================================================
+    # Status
+    # =========================================================================
+
+    def get_status(self) -> dict[str, Any]:
+        """Get exporter status."""
+        return {
+            "port": self._port,
+            "host": self._host,
+            "running": self._runner is not None,
+            "metric_count": sum(len(v) for v in self._metrics.values()),
+            "metric_names": sorted(self._metrics.keys()),
+            "uptime_seconds": round(time.time() - self._start_time, 1),
+        }

--- a/monitoring/alertmanager/alertmanager.yml
+++ b/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,27 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ["alertname", "severity"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: "default"
+  routes:
+    - match:
+        severity: critical
+      receiver: "default"
+      repeat_interval: 1h
+
+receivers:
+  - name: "default"
+    webhook_configs:
+      - url: "http://bot:8080/api/alerts"
+        send_resolved: true
+
+inhibit_rules:
+  - source_match:
+      severity: "critical"
+    target_match:
+      severity: "warning"
+    equal: ["alertname"]

--- a/monitoring/grafana/dashboards/traderagent.json
+++ b/monitoring/grafana/dashboards/traderagent.json
@@ -1,0 +1,209 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "Portfolio Value",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "traderagent_portfolio_value",
+          "legendFormat": "{{strategy}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Realized PnL",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "traderagent_pnl_total",
+          "legendFormat": "Realized PnL",
+          "refId": "A"
+        },
+        {
+          "expr": "traderagent_pnl_unrealized",
+          "legendFormat": "Unrealized PnL",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Active Deals",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "traderagent_active_deals",
+          "legendFormat": "Deals",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Total Trades",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "traderagent_total_trades",
+          "legendFormat": "Trades",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Bot Health",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "traderagent_health_status",
+          "legendFormat": "Health",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "UNHEALTHY", "color": "red" }, "1": { "text": "HEALTHY", "color": "green" } } }
+          ],
+          "thresholds": {
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Uptime",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "traderagent_bot_uptime_seconds",
+          "legendFormat": "Uptime",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "API Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "traderagent_api_latency_seconds",
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Grid Open Orders",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "traderagent_grid_open_orders",
+          "legendFormat": "Open Orders",
+          "refId": "A"
+        },
+        {
+          "expr": "traderagent_dca_safety_orders_filled",
+          "legendFormat": "Safety Orders Filled",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["traderagent", "trading"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "TRADERAGENT Dashboard",
+  "uid": "traderagent-main",
+  "version": 1
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "TRADERAGENT"
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: "15s"

--- a/tests/test_metrics_exporter.py
+++ b/tests/test_metrics_exporter.py
@@ -1,0 +1,217 @@
+"""Tests for MetricsExporter — Prometheus metrics HTTP endpoint."""
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase, TestClient, TestServer
+
+from bot.monitoring.metrics_exporter import (
+    METRIC_DEFINITIONS,
+    MetricValue,
+    MetricsExporter,
+)
+
+
+# =============================================================================
+# Unit Tests (no HTTP server)
+# =============================================================================
+
+
+class TestMetricOperations:
+    """Tests for metric set/increment/remove operations."""
+
+    def test_set_metric(self):
+        exporter = MetricsExporter()
+        exporter.set_metric("traderagent_portfolio_value", 10000.0)
+
+        metrics = exporter.metrics
+        assert "traderagent_portfolio_value" in metrics
+        assert metrics["traderagent_portfolio_value"][0].value == 10000.0
+
+    def test_set_metric_with_labels(self):
+        exporter = MetricsExporter()
+        exporter.set_metric(
+            "traderagent_active_deals",
+            3.0,
+            labels={"strategy": "grid", "pair": "BTCUSDT"},
+        )
+
+        metrics = exporter.metrics
+        mv = metrics["traderagent_active_deals"][0]
+        assert mv.value == 3.0
+        assert mv.labels == {"strategy": "grid", "pair": "BTCUSDT"}
+
+    def test_set_metric_replaces_same_labels(self):
+        exporter = MetricsExporter()
+        exporter.set_metric("traderagent_pnl_total", 100.0)
+        exporter.set_metric("traderagent_pnl_total", 200.0)
+
+        metrics = exporter.metrics
+        assert len(metrics["traderagent_pnl_total"]) == 1
+        assert metrics["traderagent_pnl_total"][0].value == 200.0
+
+    def test_set_metric_different_labels_adds(self):
+        exporter = MetricsExporter()
+        exporter.set_metric("traderagent_active_deals", 2.0, {"strategy": "grid"})
+        exporter.set_metric("traderagent_active_deals", 1.0, {"strategy": "dca"})
+
+        metrics = exporter.metrics
+        assert len(metrics["traderagent_active_deals"]) == 2
+
+    def test_increment(self):
+        exporter = MetricsExporter()
+        exporter.increment("traderagent_total_trades")
+        exporter.increment("traderagent_total_trades")
+        exporter.increment("traderagent_total_trades", 3.0)
+
+        metrics = exporter.metrics
+        assert metrics["traderagent_total_trades"][0].value == 5.0
+
+    def test_increment_with_labels(self):
+        exporter = MetricsExporter()
+        exporter.increment("traderagent_total_trades", labels={"pair": "BTCUSDT"})
+        exporter.increment("traderagent_total_trades", labels={"pair": "ETHUSDT"})
+        exporter.increment("traderagent_total_trades", labels={"pair": "BTCUSDT"})
+
+        metrics = exporter.metrics
+        values = metrics["traderagent_total_trades"]
+        btc = next(v for v in values if v.labels.get("pair") == "BTCUSDT")
+        eth = next(v for v in values if v.labels.get("pair") == "ETHUSDT")
+        assert btc.value == 2.0
+        assert eth.value == 1.0
+
+    def test_remove_metric(self):
+        exporter = MetricsExporter()
+        exporter.set_metric("traderagent_pnl_total", 100.0)
+        exporter.remove_metric("traderagent_pnl_total")
+
+        assert "traderagent_pnl_total" not in exporter.metrics
+
+    def test_clear(self):
+        exporter = MetricsExporter()
+        exporter.set_metric("traderagent_pnl_total", 100.0)
+        exporter.set_metric("traderagent_active_deals", 5.0)
+        exporter.clear()
+
+        assert len(exporter.metrics) == 0
+
+
+class TestPrometheusFormat:
+    """Tests for Prometheus text format output."""
+
+    def test_format_basic_metric(self):
+        exporter = MetricsExporter()
+        exporter.set_metric("traderagent_health_status", 1.0)
+
+        output = exporter.format_metrics()
+        assert "traderagent_health_status 1.0" in output
+
+    def test_format_includes_help(self):
+        exporter = MetricsExporter()
+        exporter.set_metric("traderagent_portfolio_value", 10000.0)
+
+        output = exporter.format_metrics()
+        assert "# HELP traderagent_portfolio_value" in output
+        assert "# TYPE traderagent_portfolio_value gauge" in output
+
+    def test_format_counter_type(self):
+        exporter = MetricsExporter()
+        exporter.set_metric("traderagent_total_trades", 42.0)
+
+        output = exporter.format_metrics()
+        assert "# TYPE traderagent_total_trades counter" in output
+
+    def test_format_with_labels(self):
+        exporter = MetricsExporter()
+        exporter.set_metric(
+            "traderagent_active_deals",
+            3.0,
+            {"strategy": "grid"},
+        )
+
+        output = exporter.format_metrics()
+        assert 'traderagent_active_deals{strategy="grid"} 3.0' in output
+
+    def test_format_multiple_labels_sorted(self):
+        exporter = MetricsExporter()
+        exporter.set_metric(
+            "traderagent_active_deals",
+            2.0,
+            {"strategy": "dca", "pair": "BTCUSDT"},
+        )
+
+        output = exporter.format_metrics()
+        assert 'pair="BTCUSDT",strategy="dca"' in output
+
+    def test_format_includes_uptime(self):
+        exporter = MetricsExporter()
+        output = exporter.format_metrics()
+        assert "traderagent_bot_uptime_seconds" in output
+
+    def test_format_ends_with_newline(self):
+        exporter = MetricsExporter()
+        exporter.set_metric("traderagent_health_status", 1.0)
+        output = exporter.format_metrics()
+        assert output.endswith("\n")
+
+
+class TestMetricDefinitions:
+    """Tests for metric definitions."""
+
+    def test_definitions_exist(self):
+        assert len(METRIC_DEFINITIONS) > 0
+
+    def test_all_definitions_have_type_and_help(self):
+        for name, (mtype, help_text) in METRIC_DEFINITIONS.items():
+            assert mtype in ("gauge", "counter"), f"{name} has invalid type: {mtype}"
+            assert len(help_text) > 0, f"{name} has empty help text"
+
+
+class TestExporterStatus:
+    """Tests for exporter status reporting."""
+
+    def test_get_status(self):
+        exporter = MetricsExporter(port=9200)
+        exporter.set_metric("traderagent_health_status", 1.0)
+
+        status = exporter.get_status()
+        assert status["port"] == 9200
+        assert status["running"] is False
+        assert status["metric_count"] == 1
+        assert "traderagent_health_status" in status["metric_names"]
+
+
+class TestHTTPEndpoints:
+    """Tests for HTTP /metrics and /health endpoints."""
+
+    async def test_metrics_endpoint(self):
+        exporter = MetricsExporter(port=0)
+        exporter.set_metric("traderagent_health_status", 1.0)
+
+        app = web.Application()
+        app.router.add_get("/metrics", exporter._handle_metrics)
+
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/metrics")
+            assert resp.status == 200
+            text = await resp.text()
+            assert "traderagent_health_status" in text
+            assert "text/plain" in resp.content_type
+
+    async def test_health_endpoint(self):
+        exporter = MetricsExporter(port=0)
+
+        app = web.Application()
+        app.router.add_get("/health", exporter._handle_health)
+
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/health")
+            assert resp.status == 200
+            text = await resp.text()
+            assert text == "ok"
+
+    async def test_start_stop(self):
+        exporter = MetricsExporter(port=19876)
+        await exporter.start()
+        assert exporter._runner is not None
+        await exporter.stop()
+        assert exporter._runner is None


### PR DESCRIPTION
## Summary
- **MetricsExporter**: aiohttp-based Prometheus `/metrics` endpoint with labeled metrics (gauges + counters), `/health` check
- **Dockerfile.exporter**: Container for bot-exporter service referenced in docker-compose.monitoring.yml
- **.dockerignore**: Optimized build context (excludes .git, tests, docs, screenshots, experiments)
- **Grafana provisioning**: Prometheus datasource auto-config + dashboard provider
- **Grafana dashboard**: 8-panel dashboard (Portfolio Value, PnL, Active Deals, Health, Uptime, API Latency, Grid Orders)
- **AlertManager config**: Webhook receiver, severity-based routing, critical→warning inhibition rules

Closes #168

## Test plan
- [x] 21 tests across 5 test classes, all passing
- [x] Metric operations: set, increment, labels, remove, clear
- [x] Prometheus format: HELP/TYPE headers, labeled output, counter/gauge types, uptime auto-metric
- [x] Metric definitions: all have valid type and help text
- [x] HTTP endpoints: /metrics returns 200 with Prometheus format, /health returns "ok"
- [x] Server lifecycle: start/stop without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)