### PR TITLE
feat: Multi-timeframe backtesting engine (#172)

### DIFF
--- a/bot/tests/backtesting/__init__.py
+++ b/bot/tests/backtesting/__init__.py
@@ -2,6 +2,16 @@
 
 from .backtesting_engine import BacktestingEngine
 from .market_simulator import MarketSimulator
+from .multi_tf_data_loader import MultiTimeframeData, MultiTimeframeDataLoader
+from .multi_tf_engine import MultiTFBacktestConfig, MultiTimeframeBacktestEngine
 from .test_data import HistoricalDataProvider
 
-__all__ = ["MarketSimulator", "BacktestingEngine", "HistoricalDataProvider"]
+__all__ = [
+    "MarketSimulator",
+    "BacktestingEngine",
+    "HistoricalDataProvider",
+    "MultiTimeframeDataLoader",
+    "MultiTimeframeData",
+    "MultiTimeframeBacktestEngine",
+    "MultiTFBacktestConfig",
+]

--- a/bot/tests/backtesting/multi_tf_data_loader.py
+++ b/bot/tests/backtesting/multi_tf_data_loader.py
@@ -1,0 +1,156 @@
+"""
+Multi-timeframe data loader for backtesting.
+
+Generates or loads synchronized OHLCV data across D1, H4, H1, M15
+timeframes. Data is generated at M15 resolution first, then aggregated
+upward using pandas resample to ensure perfect timestamp alignment.
+
+Usage:
+    loader = MultiTimeframeDataLoader()
+    data = loader.load("BTC/USDT", start, end, trend="up")
+    df_d1, df_h4, df_h1, df_m15 = loader.get_context_at(data, m15_index=200, lookback=50)
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+import pandas as pd
+
+from bot.tests.backtesting.test_data import HistoricalDataProvider
+
+
+@dataclass
+class MultiTimeframeData:
+    """Container for synchronized multi-timeframe OHLCV DataFrames."""
+
+    d1: pd.DataFrame
+    h4: pd.DataFrame
+    h1: pd.DataFrame
+    m15: pd.DataFrame
+
+    def as_tuple(self) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+        """Return (d1, h4, h1, m15) tuple for unpacking."""
+        return (self.d1, self.h4, self.h1, self.m15)
+
+
+class MultiTimeframeDataLoader:
+    """
+    Loads/generates synchronized OHLCV data across D1, H4, H1, M15.
+
+    Data is generated at M15 resolution first, then aggregated upward
+    to ensure perfect alignment. Every M15 candle has a corresponding
+    parent candle in H1, H4, and D1.
+    """
+
+    def __init__(self, provider: HistoricalDataProvider | None = None) -> None:
+        self._provider = provider or HistoricalDataProvider()
+
+    def load(
+        self,
+        symbol: str,
+        start_date: datetime,
+        end_date: datetime,
+        trend: str = "up",
+        base_price: Decimal = Decimal("45000"),
+    ) -> MultiTimeframeData:
+        """
+        Generate synchronized multi-TF data.
+
+        1. Generate M15 candles using HistoricalDataProvider.
+        2. Convert to DataFrame with DatetimeIndex.
+        3. Resample/aggregate into H1, H4, D1.
+
+        Args:
+            symbol: Trading pair (e.g. "BTC/USDT").
+            start_date: Start datetime.
+            end_date: End datetime.
+            trend: "up", "down", or "sideways".
+            base_price: Starting price for synthetic data.
+
+        Returns:
+            MultiTimeframeData with all four aligned DataFrames.
+        """
+        # Generate M15 candles
+        candles = self._provider.generate_trending_data(
+            symbol=symbol,
+            start_date=start_date,
+            end_date=end_date,
+            interval="15m",
+            trend=trend,
+            base_price=base_price,
+        )
+
+        # Convert to DataFrame with DatetimeIndex
+        df_m15 = self._candles_to_dataframe(candles)
+
+        # Resample to higher timeframes
+        df_h1 = self._resample(df_m15, "1h")
+        df_h4 = self._resample(df_m15, "4h")
+        df_d1 = self._resample(df_m15, "1D")
+
+        return MultiTimeframeData(d1=df_d1, h4=df_h4, h1=df_h1, m15=df_m15)
+
+    def _candles_to_dataframe(self, candles: list[dict]) -> pd.DataFrame:
+        """Convert list-of-dicts candles to OHLCV DataFrame with DatetimeIndex."""
+        df = pd.DataFrame(candles)
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        df = df.set_index("timestamp")
+        df = df.sort_index()
+        return df[["open", "high", "low", "close", "volume"]]
+
+    def _resample(self, df_m15: pd.DataFrame, rule: str) -> pd.DataFrame:
+        """
+        Resample M15 data to a higher timeframe.
+
+        Uses standard OHLCV aggregation:
+          open: first, high: max, low: min, close: last, volume: sum
+
+        Args:
+            df_m15: M15 DataFrame with DatetimeIndex.
+            rule: Pandas resample rule ('1h', '4h', '1D').
+
+        Returns:
+            Resampled DataFrame.
+        """
+        resampled = df_m15.resample(rule).agg({
+            "open": "first",
+            "high": "max",
+            "low": "min",
+            "close": "last",
+            "volume": "sum",
+        }).dropna()
+        return resampled
+
+    def get_context_at(
+        self,
+        data: MultiTimeframeData,
+        m15_index: int,
+        lookback: int = 100,
+    ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+        """
+        Get rolling context DataFrames at a specific M15 bar index.
+
+        For each timeframe, returns the last `lookback` completed candles
+        as of the M15 timestamp.
+
+        Args:
+            data: Full MultiTimeframeData.
+            m15_index: Current position in M15 DataFrame (0-based).
+            lookback: Number of historical bars to include per TF.
+
+        Returns:
+            (df_d1, df_h4, df_h1, df_m15) tuple of rolling windows.
+        """
+        current_ts = data.m15.index[m15_index]
+
+        # M15: simple slice
+        start = max(0, m15_index - lookback + 1)
+        df_m15 = data.m15.iloc[start : m15_index + 1]
+
+        # Higher TFs: all candles with timestamp <= current M15 timestamp
+        df_h1 = data.h1[data.h1.index <= current_ts].tail(lookback)
+        df_h4 = data.h4[data.h4.index <= current_ts].tail(lookback)
+        df_d1 = data.d1[data.d1.index <= current_ts].tail(lookback)
+
+        return (df_d1, df_h4, df_h1, df_m15)

--- a/bot/tests/backtesting/multi_tf_engine.py
+++ b/bot/tests/backtesting/multi_tf_engine.py
@@ -1,0 +1,404 @@
+"""
+Multi-timeframe backtest engine that drives BaseStrategy implementations.
+
+Iterates M15 candles as the finest granularity, builds rolling DataFrames
+for each timeframe, and executes the full BaseStrategy lifecycle:
+analyze_market → generate_signal → open_position → update_positions → close_position.
+
+Usage:
+    engine = MultiTimeframeBacktestEngine()
+    result = await engine.run(strategy, data)
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+import pandas as pd
+
+from bot.strategies.base import BaseStrategy, ExitReason, SignalDirection
+from bot.tests.backtesting.backtesting_engine import BacktestResult
+from bot.tests.backtesting.market_simulator import MarketSimulator
+from bot.tests.backtesting.multi_tf_data_loader import (
+    MultiTimeframeData,
+    MultiTimeframeDataLoader,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MultiTFBacktestConfig:
+    """Configuration for multi-timeframe backtest."""
+
+    symbol: str = "BTC/USDT"
+    initial_balance: Decimal = Decimal("10000")
+    lookback: int = 100
+    warmup_bars: int = 50
+    analyze_every_n: int = 4
+    risk_per_trade: Decimal = Decimal("0.02")
+    max_position_pct: Decimal = Decimal("0.5")
+
+
+class MultiTimeframeBacktestEngine:
+    """
+    Backtest engine that executes BaseStrategy with multi-timeframe data.
+
+    Execution loop (per M15 candle after warmup):
+        1. Build rolling context DataFrames for D1, H4, H1, M15
+        2. Set current price on MarketSimulator
+        3. Periodically call strategy.analyze_market(df_d1, df_h4, df_h1, df_m15)
+        4. Call strategy.generate_signal(df_m15, current_balance)
+        5. If signal, open position + place order via simulator
+        6. Call strategy.update_positions(current_price, df_m15)
+        7. If exits, close positions + execute sell via simulator
+        8. Record equity curve point
+    """
+
+    def __init__(self, config: MultiTFBacktestConfig | None = None) -> None:
+        self.config = config or MultiTFBacktestConfig()
+        self.data_loader = MultiTimeframeDataLoader()
+        self._position_amounts: dict[str, Decimal] = {}
+
+    async def run(
+        self,
+        strategy: BaseStrategy,
+        data: MultiTimeframeData,
+    ) -> BacktestResult:
+        """
+        Run a full multi-timeframe backtest.
+
+        Args:
+            strategy: A BaseStrategy implementation.
+            data: Pre-loaded MultiTimeframeData.
+
+        Returns:
+            BacktestResult with full metrics.
+        """
+        # Reset strategy state
+        strategy.reset()
+
+        # Create fresh simulator
+        simulator = MarketSimulator(
+            symbol=self.config.symbol,
+            initial_balance_quote=self.config.initial_balance,
+        )
+
+        # Run execution loop
+        equity_curve, max_drawdown = await self._execute_loop(
+            strategy, data, simulator
+        )
+
+        # Build result
+        return self._build_result(
+            strategy_name=strategy.get_strategy_name(),
+            simulator=simulator,
+            equity_curve=equity_curve,
+            max_drawdown=max_drawdown,
+            start_time=data.m15.index[0].to_pydatetime(),
+            end_time=data.m15.index[-1].to_pydatetime(),
+        )
+
+    async def run_with_generated_data(
+        self,
+        strategy: BaseStrategy,
+        start_date: datetime,
+        end_date: datetime,
+        trend: str = "up",
+        base_price: Decimal = Decimal("45000"),
+    ) -> BacktestResult:
+        """Convenience: generate data and run backtest."""
+        data = self.data_loader.load(
+            symbol=self.config.symbol,
+            start_date=start_date,
+            end_date=end_date,
+            trend=trend,
+            base_price=base_price,
+        )
+        return await self.run(strategy, data)
+
+    async def _execute_loop(
+        self,
+        strategy: BaseStrategy,
+        data: MultiTimeframeData,
+        simulator: MarketSimulator,
+    ) -> tuple[list[dict[str, Any]], Decimal]:
+        """
+        Core execution loop.
+
+        Returns:
+            (equity_curve, max_drawdown)
+        """
+        equity_curve: list[dict[str, Any]] = []
+        peak_value = self.config.initial_balance
+        max_drawdown = Decimal("0")
+        self._position_amounts = {}
+
+        total_bars = len(data.m15)
+
+        for i in range(self.config.warmup_bars, total_bars):
+            # Get rolling context
+            df_d1, df_h4, df_h1, df_m15 = self.data_loader.get_context_at(
+                data, m15_index=i, lookback=self.config.lookback
+            )
+
+            # Current price from M15 close
+            current_price = Decimal(str(data.m15.iloc[i]["close"]))
+            simulator.set_price(current_price)
+
+            # Periodically analyze market
+            if (i - self.config.warmup_bars) % self.config.analyze_every_n == 0:
+                try:
+                    strategy.analyze_market(df_d1, df_h4, df_h1, df_m15)
+                except Exception as e:
+                    logger.debug("analyze_market error at bar %d: %s", i, e)
+
+            # Generate signal
+            try:
+                balance = simulator.get_portfolio_value()
+                signal = strategy.generate_signal(df_m15, balance)
+            except Exception as e:
+                logger.debug("generate_signal error at bar %d: %s", i, e)
+                signal = None
+
+            # Open position if signal
+            if signal is not None:
+                await self._handle_signal_execution(
+                    strategy, signal, current_price, simulator
+                )
+
+            # Update positions and handle exits
+            try:
+                exits = strategy.update_positions(current_price, df_m15)
+            except Exception as e:
+                logger.debug("update_positions error at bar %d: %s", i, e)
+                exits = []
+
+            if exits:
+                await self._handle_exits(
+                    strategy, exits, current_price, simulator
+                )
+
+            # Record equity curve
+            portfolio_value = simulator.get_portfolio_value()
+            equity_curve.append({
+                "timestamp": data.m15.index[i].isoformat(),
+                "price": float(current_price),
+                "portfolio_value": float(portfolio_value),
+            })
+
+            # Update drawdown
+            if portfolio_value > peak_value:
+                peak_value = portfolio_value
+            else:
+                drawdown = peak_value - portfolio_value
+                if drawdown > max_drawdown:
+                    max_drawdown = drawdown
+
+            # Yield to event loop
+            await asyncio.sleep(0)
+
+        return equity_curve, max_drawdown
+
+    async def _handle_signal_execution(
+        self,
+        strategy: BaseStrategy,
+        signal: Any,
+        current_price: Decimal,
+        simulator: MarketSimulator,
+    ) -> None:
+        """Open position in strategy and place market order on simulator."""
+        # Only handle LONG signals (simulator has no short selling)
+        if signal.direction != SignalDirection.LONG:
+            logger.debug("Skipping SHORT signal (not supported)")
+            return
+
+        # Calculate position size
+        balance = simulator.get_portfolio_value()
+        position_size = self._calculate_position_size(signal, balance, current_price)
+        if position_size <= 0:
+            return
+
+        # Check if we can afford this
+        cost = position_size * current_price
+        if cost > simulator.balance.quote:
+            return
+
+        try:
+            # Open position in strategy
+            pos_id = strategy.open_position(signal, cost)
+
+            # Place buy order on simulator
+            await simulator.create_order(
+                symbol=self.config.symbol,
+                order_type="market",
+                side="buy",
+                amount=position_size,
+            )
+
+            # Track amount for closing later
+            self._position_amounts[pos_id] = position_size
+        except Exception as e:
+            logger.debug("Signal execution failed: %s", e)
+
+    async def _handle_exits(
+        self,
+        strategy: BaseStrategy,
+        exits: list[tuple[str, ExitReason]],
+        current_price: Decimal,
+        simulator: MarketSimulator,
+    ) -> None:
+        """Close positions in strategy and execute sell orders on simulator."""
+        for pos_id, exit_reason in exits:
+            amount = self._position_amounts.pop(pos_id, None)
+            if amount is None:
+                continue
+
+            try:
+                # Close in strategy
+                strategy.close_position(pos_id, exit_reason, current_price)
+
+                # Sell on simulator
+                if simulator.balance.base >= amount:
+                    await simulator.create_order(
+                        symbol=self.config.symbol,
+                        order_type="market",
+                        side="sell",
+                        amount=amount,
+                    )
+            except Exception as e:
+                logger.debug("Exit execution failed for %s: %s", pos_id, e)
+
+    def _calculate_position_size(
+        self,
+        signal: Any,
+        current_balance: Decimal,
+        current_price: Decimal,
+    ) -> Decimal:
+        """Calculate position size in base currency."""
+        risk_amount = current_balance * self.config.risk_per_trade
+        stop_distance = abs(signal.entry_price - signal.stop_loss)
+
+        if stop_distance <= 0:
+            return Decimal("0")
+
+        # Position value based on risk
+        position_value = (risk_amount / stop_distance) * current_price
+
+        # Cap at max percentage of balance
+        max_value = current_balance * self.config.max_position_pct
+        position_value = min(position_value, max_value)
+
+        # Convert to base currency amount
+        if current_price <= 0:
+            return Decimal("0")
+
+        return position_value / current_price
+
+    def _build_result(
+        self,
+        strategy_name: str,
+        simulator: MarketSimulator,
+        equity_curve: list[dict[str, Any]],
+        max_drawdown: Decimal,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> BacktestResult:
+        """Build BacktestResult from simulator state."""
+        trade_history = simulator.get_trade_history()
+        final_balance = simulator.get_portfolio_value()
+        initial = self.config.initial_balance
+        total_return = final_balance - initial
+        total_return_pct = (
+            (total_return / initial) * Decimal("100") if initial > 0 else Decimal("0")
+        )
+        max_drawdown_pct = (
+            (max_drawdown / initial) * Decimal("100") if initial > 0 else Decimal("0")
+        )
+
+        # Analyze trades
+        buy_orders = [t for t in trade_history if t["side"] == "buy"]
+        sell_orders = [t for t in trade_history if t["side"] == "sell"]
+        winning_trades = 0
+        losing_trades = 0
+        total_profit = Decimal("0")
+
+        for i in range(min(len(buy_orders), len(sell_orders))):
+            buy_price = Decimal(str(buy_orders[i]["price"]))
+            sell_price = Decimal(str(sell_orders[i]["price"]))
+            amount = Decimal(str(buy_orders[i]["amount"]))
+            profit = (sell_price - buy_price) * amount
+            total_profit += profit
+            if profit > 0:
+                winning_trades += 1
+            else:
+                losing_trades += 1
+
+        total_trades = winning_trades + losing_trades
+        win_rate = (
+            Decimal(winning_trades) / Decimal(total_trades) * Decimal("100")
+            if total_trades > 0
+            else Decimal("0")
+        )
+        avg_profit = (
+            total_profit / Decimal(total_trades) if total_trades > 0 else Decimal("0")
+        )
+
+        # Sharpe ratio
+        sharpe_ratio = self._calculate_sharpe_ratio(equity_curve)
+
+        return BacktestResult(
+            strategy_name=strategy_name,
+            symbol=self.config.symbol,
+            start_time=start_time,
+            end_time=end_time,
+            duration=end_time - start_time,
+            initial_balance=initial,
+            final_balance=final_balance,
+            total_return=total_return,
+            total_return_pct=total_return_pct,
+            max_drawdown=max_drawdown,
+            max_drawdown_pct=max_drawdown_pct,
+            total_trades=total_trades,
+            winning_trades=winning_trades,
+            losing_trades=losing_trades,
+            win_rate=win_rate,
+            total_buy_orders=len(buy_orders),
+            total_sell_orders=len(sell_orders),
+            avg_profit_per_trade=avg_profit,
+            sharpe_ratio=sharpe_ratio,
+            trade_history=trade_history,
+            equity_curve=equity_curve,
+        )
+
+    def _calculate_sharpe_ratio(
+        self, equity_curve: list[dict[str, Any]]
+    ) -> Decimal | None:
+        """Calculate Sharpe ratio from equity curve."""
+        if len(equity_curve) < 2:
+            return None
+
+        returns = []
+        for i in range(1, len(equity_curve)):
+            prev = Decimal(str(equity_curve[i - 1]["portfolio_value"]))
+            curr = Decimal(str(equity_curve[i]["portfolio_value"]))
+            if prev > 0:
+                returns.append((curr - prev) / prev)
+
+        if not returns:
+            return None
+
+        mean_return = sum(returns) / len(returns)
+        variance = sum((r - mean_return) ** 2 for r in returns) / len(returns)
+        std_return = variance.sqrt() if variance > 0 else Decimal("0")
+
+        if std_return > 0:
+            sharpe = mean_return / std_return
+            # Annualize (assuming 15-minute returns)
+            sharpe = sharpe * Decimal(str((365 * 24 * 4) ** 0.5))
+            return sharpe
+
+        return None

--- a/bot/tests/backtesting/test_multi_tf_backtesting.py
+++ b/bot/tests/backtesting/test_multi_tf_backtesting.py
@@ -1,0 +1,447 @@
+"""Tests for multi-timeframe backtesting — Issue #172."""
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+
+from bot.tests.backtesting.backtesting_engine import BacktestResult
+from bot.tests.backtesting.multi_tf_data_loader import (
+    MultiTimeframeData,
+    MultiTimeframeDataLoader,
+)
+from bot.tests.backtesting.multi_tf_engine import (
+    MultiTFBacktestConfig,
+    MultiTimeframeBacktestEngine,
+)
+
+# Reuse ConcreteStrategy from existing tests
+from tests.strategies.test_base_strategy import ConcreteStrategy
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def loader():
+    return MultiTimeframeDataLoader()
+
+
+@pytest.fixture
+def data_2days(loader):
+    """2 days of uptrend data."""
+    return loader.load(
+        symbol="BTC/USDT",
+        start_date=datetime(2024, 1, 1),
+        end_date=datetime(2024, 1, 3),
+        trend="up",
+    )
+
+
+@pytest.fixture
+def data_7days(loader):
+    """7 days of uptrend data — enough for warmup + execution."""
+    return loader.load(
+        symbol="BTC/USDT",
+        start_date=datetime(2024, 1, 1),
+        end_date=datetime(2024, 1, 8),
+        trend="up",
+    )
+
+
+@pytest.fixture
+def engine():
+    config = MultiTFBacktestConfig(
+        symbol="BTC/USDT",
+        initial_balance=Decimal("10000"),
+        warmup_bars=20,
+    )
+    return MultiTimeframeBacktestEngine(config=config)
+
+
+# =============================================================================
+# MultiTimeframeDataLoader Tests
+# =============================================================================
+
+
+class TestMultiTimeframeDataLoader:
+    """Tests for data loading and synchronization."""
+
+    def test_load_produces_four_dataframes(self, data_2days):
+        assert isinstance(data_2days.d1, pd.DataFrame)
+        assert isinstance(data_2days.h4, pd.DataFrame)
+        assert isinstance(data_2days.h1, pd.DataFrame)
+        assert isinstance(data_2days.m15, pd.DataFrame)
+
+    def test_as_tuple(self, data_2days):
+        t = data_2days.as_tuple()
+        assert len(t) == 4
+        assert t[0] is data_2days.d1
+        assert t[3] is data_2days.m15
+
+    def test_dataframe_columns(self, data_2days):
+        expected = {"open", "high", "low", "close", "volume"}
+        for df in [data_2days.d1, data_2days.h4, data_2days.h1, data_2days.m15]:
+            assert set(df.columns) >= expected
+
+    def test_m15_count(self, data_2days):
+        """2 days = 2*24*4 = 192 M15 bars."""
+        assert len(data_2days.m15) == 192
+
+    def test_h1_count(self, data_2days):
+        """2 days = 48 H1 bars."""
+        assert len(data_2days.h1) == 48
+
+    def test_h4_count(self, data_2days):
+        """2 days = 12 H4 bars."""
+        assert len(data_2days.h4) == 12
+
+    def test_d1_count(self, data_2days):
+        """2 days = 2 D1 bars."""
+        assert len(data_2days.d1) == 2
+
+    def test_datetime_index(self, data_2days):
+        for df in [data_2days.d1, data_2days.h4, data_2days.h1, data_2days.m15]:
+            assert isinstance(df.index, pd.DatetimeIndex)
+
+    def test_timeframe_alignment(self, data_2days):
+        """Each M15 timestamp should have a corresponding H1 and H4 ancestor."""
+        for ts in data_2days.m15.index:
+            h1_before = data_2days.h1[data_2days.h1.index <= ts]
+            assert len(h1_before) > 0, f"No H1 candle for M15 at {ts}"
+
+            h4_before = data_2days.h4[data_2days.h4.index <= ts]
+            assert len(h4_before) > 0, f"No H4 candle for M15 at {ts}"
+
+    def test_ohlcv_consistency(self, data_2days):
+        """high >= max(open, close) and low <= min(open, close) for all bars."""
+        for df in [data_2days.d1, data_2days.h4, data_2days.h1, data_2days.m15]:
+            assert (df["high"] >= df[["open", "close"]].max(axis=1) - 1e-10).all()
+            assert (df["low"] <= df[["open", "close"]].min(axis=1) + 1e-10).all()
+
+    def test_resampled_high_equals_child_max(self, data_2days):
+        """H1 high should equal max of its 4 M15 highs."""
+        h1_ts = data_2days.h1.index[0]
+        m15_slice = data_2days.m15[
+            (data_2days.m15.index >= h1_ts)
+            & (data_2days.m15.index < h1_ts + pd.Timedelta(hours=1))
+        ]
+        assert abs(data_2days.h1.loc[h1_ts, "high"] - m15_slice["high"].max()) < 1e-10
+
+    def test_resampled_open_equals_first_child(self, data_2days):
+        """H1 open should equal the open of its first M15 bar."""
+        h1_ts = data_2days.h1.index[0]
+        m15_slice = data_2days.m15[
+            (data_2days.m15.index >= h1_ts)
+            & (data_2days.m15.index < h1_ts + pd.Timedelta(hours=1))
+        ]
+        assert abs(data_2days.h1.loc[h1_ts, "open"] - m15_slice.iloc[0]["open"]) < 1e-10
+
+    def test_resampled_close_equals_last_child(self, data_2days):
+        """H1 close should equal the close of its last M15 bar."""
+        h1_ts = data_2days.h1.index[0]
+        m15_slice = data_2days.m15[
+            (data_2days.m15.index >= h1_ts)
+            & (data_2days.m15.index < h1_ts + pd.Timedelta(hours=1))
+        ]
+        assert abs(data_2days.h1.loc[h1_ts, "close"] - m15_slice.iloc[-1]["close"]) < 1e-10
+
+    def test_resampled_volume_equals_child_sum(self, data_2days):
+        """H1 volume should equal sum of its 4 M15 volumes."""
+        h1_ts = data_2days.h1.index[0]
+        m15_slice = data_2days.m15[
+            (data_2days.m15.index >= h1_ts)
+            & (data_2days.m15.index < h1_ts + pd.Timedelta(hours=1))
+        ]
+        assert abs(data_2days.h1.loc[h1_ts, "volume"] - m15_slice["volume"].sum()) < 1e-10
+
+
+class TestGetContextAt:
+    """Tests for get_context_at rolling window."""
+
+    def test_context_sizes(self, loader, data_7days):
+        df_d1, df_h4, df_h1, df_m15 = loader.get_context_at(
+            data_7days, m15_index=200, lookback=50
+        )
+        assert len(df_m15) == 50
+        assert len(df_h1) <= 50
+        assert len(df_h4) <= 50
+        assert len(df_d1) <= 50
+
+    def test_context_early_index(self, loader, data_7days):
+        """When m15_index < lookback, return whatever is available."""
+        df_d1, df_h4, df_h1, df_m15 = loader.get_context_at(
+            data_7days, m15_index=10, lookback=50
+        )
+        assert len(df_m15) == 11  # indices 0..10
+        assert len(df_d1) >= 1
+
+    def test_context_timestamps_aligned(self, loader, data_7days):
+        """Context DataFrames should not contain future data."""
+        m15_index = 200
+        current_ts = data_7days.m15.index[m15_index]
+        df_d1, df_h4, df_h1, df_m15 = loader.get_context_at(
+            data_7days, m15_index=m15_index, lookback=50
+        )
+        assert df_m15.index[-1] == current_ts
+        assert df_h1.index[-1] <= current_ts
+        assert df_h4.index[-1] <= current_ts
+        assert df_d1.index[-1] <= current_ts
+
+    def test_context_no_future_leak(self, loader, data_7days):
+        """No candle in any context DataFrame should be after current timestamp."""
+        m15_index = 100
+        current_ts = data_7days.m15.index[m15_index]
+        df_d1, df_h4, df_h1, df_m15 = loader.get_context_at(
+            data_7days, m15_index=m15_index, lookback=50
+        )
+        for df in [df_d1, df_h4, df_h1, df_m15]:
+            assert (df.index <= current_ts).all()
+
+
+class TestDataLoaderTrends:
+    """Test different trend modes."""
+
+    def test_uptrend_prices_increase(self, loader):
+        data = loader.load(
+            "BTC/USDT", datetime(2024, 1, 1), datetime(2024, 2, 1), trend="up"
+        )
+        first_close = data.m15.iloc[0]["close"]
+        last_close = data.m15.iloc[-1]["close"]
+        # In an uptrend over 1 month, last price should generally be higher
+        # Allow some tolerance since it's stochastic
+        assert last_close > first_close * 0.8
+
+    def test_downtrend_prices_decrease(self, loader):
+        data = loader.load(
+            "BTC/USDT", datetime(2024, 1, 1), datetime(2024, 2, 1), trend="down"
+        )
+        first_close = data.m15.iloc[0]["close"]
+        last_close = data.m15.iloc[-1]["close"]
+        assert last_close < first_close * 1.2
+
+
+# =============================================================================
+# MultiTFBacktestConfig Tests
+# =============================================================================
+
+
+class TestMultiTFBacktestConfig:
+    def test_defaults(self):
+        config = MultiTFBacktestConfig()
+        assert config.symbol == "BTC/USDT"
+        assert config.initial_balance == Decimal("10000")
+        assert config.lookback == 100
+        assert config.warmup_bars == 50
+        assert config.analyze_every_n == 4
+
+    def test_custom(self):
+        config = MultiTFBacktestConfig(
+            symbol="ETH/USDT",
+            initial_balance=Decimal("5000"),
+            warmup_bars=30,
+        )
+        assert config.symbol == "ETH/USDT"
+        assert config.initial_balance == Decimal("5000")
+        assert config.warmup_bars == 30
+
+
+# =============================================================================
+# MultiTimeframeBacktestEngine Tests
+# =============================================================================
+
+
+class TestMultiTimeframeBacktestEngine:
+    """Tests for backtest engine execution."""
+
+    async def test_engine_runs_without_error(self, engine, data_7days):
+        strategy = ConcreteStrategy()
+        result = await engine.run(strategy, data_7days)
+        assert result is not None
+
+    async def test_returns_backtest_result(self, engine, data_7days):
+        strategy = ConcreteStrategy()
+        result = await engine.run(strategy, data_7days)
+        assert isinstance(result, BacktestResult)
+
+    async def test_strategy_name_in_result(self, engine, data_7days):
+        strategy = ConcreteStrategy()
+        result = await engine.run(strategy, data_7days)
+        assert result.strategy_name == "test-concrete"
+
+    async def test_symbol_in_result(self, engine, data_7days):
+        strategy = ConcreteStrategy()
+        result = await engine.run(strategy, data_7days)
+        assert result.symbol == "BTC/USDT"
+
+    async def test_initial_balance_correct(self, engine, data_7days):
+        strategy = ConcreteStrategy()
+        result = await engine.run(strategy, data_7days)
+        assert result.initial_balance == Decimal("10000")
+
+    async def test_equity_curve_length(self, engine, data_7days):
+        """Equity curve entries = total M15 bars - warmup bars."""
+        strategy = ConcreteStrategy()
+        result = await engine.run(strategy, data_7days)
+        expected = len(data_7days.m15) - engine.config.warmup_bars
+        assert len(result.equity_curve) == expected
+
+    async def test_equity_curve_has_required_fields(self, engine, data_7days):
+        strategy = ConcreteStrategy()
+        result = await engine.run(strategy, data_7days)
+        assert len(result.equity_curve) > 0
+        point = result.equity_curve[0]
+        assert "timestamp" in point
+        assert "price" in point
+        assert "portfolio_value" in point
+
+    async def test_duration_set(self, engine, data_7days):
+        strategy = ConcreteStrategy()
+        result = await engine.run(strategy, data_7days)
+        assert result.duration.days >= 6
+
+    async def test_result_to_dict(self, engine, data_7days):
+        strategy = ConcreteStrategy()
+        result = await engine.run(strategy, data_7days)
+        d = result.to_dict()
+        assert d["strategy_name"] == "test-concrete"
+        assert "performance" in d
+        assert "trading_stats" in d
+
+    async def test_run_with_generated_data(self):
+        config = MultiTFBacktestConfig(
+            initial_balance=Decimal("10000"),
+            warmup_bars=20,
+        )
+        engine = MultiTimeframeBacktestEngine(config=config)
+        strategy = ConcreteStrategy()
+        result = await engine.run_with_generated_data(
+            strategy=strategy,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 8),
+            trend="up",
+        )
+        assert isinstance(result, BacktestResult)
+        assert len(result.equity_curve) > 0
+
+    async def test_different_warmup(self, data_7days):
+        """Different warmup values produce different equity curve lengths."""
+        strategy = ConcreteStrategy()
+
+        config1 = MultiTFBacktestConfig(warmup_bars=20)
+        engine1 = MultiTimeframeBacktestEngine(config=config1)
+        r1 = await engine1.run(strategy, data_7days)
+
+        config2 = MultiTFBacktestConfig(warmup_bars=40)
+        engine2 = MultiTimeframeBacktestEngine(config=config2)
+        r2 = await engine2.run(strategy, data_7days)
+
+        assert len(r1.equity_curve) > len(r2.equity_curve)
+
+
+# =============================================================================
+# Integration Tests with Real Strategy Adapters
+# =============================================================================
+
+
+class TestSMCAdapterIntegration:
+    """Integration test: run SMCStrategyAdapter through multi-TF engine."""
+
+    async def test_smc_adapter_backtest(self):
+        from bot.strategies.smc.config import SMCConfig
+        from bot.strategies.smc_adapter import SMCStrategyAdapter
+
+        # SMCStrategy.__init__ references risk_per_trade_pct and
+        # max_position_size_usd but SMCConfig has risk_per_trade and
+        # max_position_size. Provide a patched config with aliases.
+        smc_config = SMCConfig()
+        smc_config.risk_per_trade_pct = smc_config.risk_per_trade
+        smc_config.max_position_size_usd = smc_config.max_position_size
+
+        config = MultiTFBacktestConfig(
+            symbol="BTC/USDT",
+            initial_balance=Decimal("10000"),
+            warmup_bars=60,
+        )
+        engine = MultiTimeframeBacktestEngine(config=config)
+        strategy = SMCStrategyAdapter(
+            config=smc_config,
+            account_balance=Decimal("10000"),
+            name="smc-backtest",
+        )
+
+        result = await engine.run_with_generated_data(
+            strategy=strategy,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 5),
+            trend="up",
+        )
+
+        assert result.strategy_name == "smc-backtest"
+        assert result.initial_balance == Decimal("10000")
+        assert len(result.equity_curve) > 0
+
+
+class TestTrendFollowerAdapterIntegration:
+    """Integration test: run TrendFollowerAdapter through multi-TF engine."""
+
+    async def test_trend_follower_backtest(self):
+        from bot.strategies.trend_follower_adapter import TrendFollowerAdapter
+
+        config = MultiTFBacktestConfig(
+            symbol="BTC/USDT",
+            initial_balance=Decimal("10000"),
+            warmup_bars=60,
+        )
+        engine = MultiTimeframeBacktestEngine(config=config)
+        strategy = TrendFollowerAdapter(
+            initial_capital=Decimal("10000"),
+            name="tf-backtest",
+            log_trades=False,
+        )
+
+        result = await engine.run_with_generated_data(
+            strategy=strategy,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 15),
+            trend="up",
+        )
+
+        assert result.strategy_name == "tf-backtest"
+        assert result.initial_balance == Decimal("10000")
+        assert len(result.equity_curve) > 0
+
+
+class TestMultiStrategyComparison:
+    """Test running multiple strategies on the same data."""
+
+    async def test_same_data_different_strategies(self):
+        loader = MultiTimeframeDataLoader()
+        data = loader.load(
+            symbol="BTC/USDT",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 15),
+            trend="up",
+        )
+
+        config = MultiTFBacktestConfig(
+            initial_balance=Decimal("10000"),
+            warmup_bars=20,
+        )
+        engine = MultiTimeframeBacktestEngine(config=config)
+
+        # Run ConcreteStrategy
+        s1 = ConcreteStrategy()
+        r1 = await engine.run(s1, data)
+
+        # Run another ConcreteStrategy (same strategy, fresh engine)
+        engine2 = MultiTimeframeBacktestEngine(config=config)
+        s2 = ConcreteStrategy()
+        r2 = await engine2.run(s2, data)
+
+        # Both should complete with same initial balance
+        assert r1.initial_balance == r2.initial_balance
+        assert len(r1.equity_curve) == len(r2.equity_curve)


### PR DESCRIPTION
## Summary
- **MultiTimeframeDataLoader**: Generates M15 OHLCV data via `HistoricalDataProvider`, resamples to H1/H4/D1 using pandas. Provides `get_context_at()` for rolling context windows with no future data leakage.
- **MultiTimeframeBacktestEngine**: Iterates M15 candles, drives `BaseStrategy` through full lifecycle (analyze_market → generate_signal → open_position → update_positions → close_position) using `MarketSimulator` for order/balance management. Produces `BacktestResult` with Sharpe ratio, drawdown, win rate.
- **36 tests**: Data loader synchronization (14), context windows (4), trends (2), config (2), engine execution (11), integration with SMCStrategyAdapter and TrendFollowerAdapter (3)

## Files
- `bot/tests/backtesting/multi_tf_data_loader.py` — MultiTimeframeDataLoader + MultiTimeframeData
- `bot/tests/backtesting/multi_tf_engine.py` — MultiTimeframeBacktestEngine + MultiTFBacktestConfig
- `bot/tests/backtesting/test_multi_tf_backtesting.py` — 36 tests
- `bot/tests/backtesting/__init__.py` — Updated exports

## Test plan
- [x] `pytest bot/tests/backtesting/test_multi_tf_backtesting.py -p no:pdb -v` — 36/36 passed
- [x] Existing `test_backtesting.py` — pre-existing failures unchanged
- [x] SMC adapter integration test passes with patched config (documented pre-existing `risk_per_trade_pct` vs `risk_per_trade` mismatch)
- [x] TrendFollower adapter integration test passes

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)