### PR TITLE
feat: Multi-strategy backtesting with adapters and comparison (#173)

### DIFF
--- a/bot/strategies/dca_adapter.py
+++ b/bot/strategies/dca_adapter.py
@@ -1,0 +1,309 @@
+"""
+DCA Strategy Adapter — Wraps DCA logic to conform to BaseStrategy interface.
+
+Translates DCA deal lifecycle into the unified signal/position interface
+for use with BacktestEngine and StrategyComparison.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+
+from bot.strategies.base import (
+    BaseMarketAnalysis,
+    BaseSignal,
+    BaseStrategy,
+    ExitReason,
+    PositionInfo,
+    SignalDirection,
+    StrategyPerformance,
+)
+from bot.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class DCAAdapter(BaseStrategy):
+    """
+    Adapter that implements DCA strategy as BaseStrategy.
+
+    Simplified DCA for backtesting:
+    - Buys when price drops by a configurable percentage from recent high
+    - Averages down with safety orders at configurable step sizes
+    - Takes profit when price recovers by target percentage
+    """
+
+    def __init__(
+        self,
+        symbol: str = "BTC/USDT",
+        base_order_size: Decimal = Decimal("100"),
+        safety_order_size: Decimal = Decimal("200"),
+        max_safety_orders: int = 5,
+        price_deviation_pct: Decimal = Decimal("0.02"),
+        safety_step_pct: Decimal = Decimal("0.015"),
+        take_profit_pct: Decimal = Decimal("0.015"),
+        name: str = "dca-default",
+    ) -> None:
+        self._symbol = symbol
+        self._name = name
+        self._base_order_size = base_order_size
+        self._safety_order_size = safety_order_size
+        self._max_safety_orders = max_safety_orders
+        self._price_deviation_pct = price_deviation_pct
+        self._safety_step_pct = safety_step_pct
+        self._take_profit_pct = take_profit_pct
+
+        self._last_analysis: BaseMarketAnalysis | None = None
+
+        # DCA deal tracking
+        self._positions: dict[str, dict[str, Any]] = {}
+        self._closed_trades: list[dict[str, Any]] = []
+        self._recent_high = Decimal("0")
+        self._current_price = Decimal("0")
+
+    def get_strategy_name(self) -> str:
+        return self._name
+
+    def get_strategy_type(self) -> str:
+        return "dca"
+
+    def analyze_market(self, *dfs: pd.DataFrame) -> BaseMarketAnalysis:
+        """Analyze market for DCA entry conditions."""
+        df = dfs[-1] if dfs else pd.DataFrame()
+
+        if df.empty or len(df) < 5:
+            return BaseMarketAnalysis(
+                trend="unknown",
+                trend_strength=0.0,
+                volatility=0.0,
+                timestamp=datetime.now(timezone.utc),
+                strategy_type="dca",
+            )
+
+        close = df["close"].values
+        self._current_price = Decimal(str(close[-1]))
+
+        # Track recent high for DCA entry
+        recent_high = float(max(close[-20:]))
+        self._recent_high = Decimal(str(recent_high))
+
+        # Volatility
+        high = df["high"].values
+        low = df["low"].values
+        tr = high - low
+        atr = float(np.mean(tr[-14:])) if len(tr) >= 14 else float(np.mean(tr))
+        volatility = atr / float(close[-1]) if close[-1] > 0 else 0.0
+
+        # Trend
+        price_change = (close[-1] - close[0]) / close[0] if close[0] > 0 else 0.0
+        if price_change < -0.02:
+            trend = "bearish"
+            trend_strength = min(abs(price_change) * 10, 1.0)
+        elif price_change > 0.02:
+            trend = "bullish"
+            trend_strength = min(abs(price_change) * 10, 1.0)
+        else:
+            trend = "sideways"
+            trend_strength = 0.3
+
+        self._last_analysis = BaseMarketAnalysis(
+            trend=trend,
+            trend_strength=trend_strength,
+            volatility=volatility,
+            timestamp=datetime.now(timezone.utc),
+            strategy_type="dca",
+            details={
+                "recent_high": float(self._recent_high),
+                "deviation_from_high": float(
+                    (self._recent_high - self._current_price) / self._recent_high
+                )
+                if self._recent_high > 0
+                else 0.0,
+            },
+        )
+        return self._last_analysis
+
+    def generate_signal(
+        self, df: pd.DataFrame, current_balance: Decimal
+    ) -> Optional[BaseSignal]:
+        """Generate DCA entry signal when price drops from recent high."""
+        if df.empty or self._recent_high <= 0:
+            return None
+
+        close = Decimal(str(df["close"].iloc[-1]))
+        self._current_price = close
+
+        # Check if we already have an active deal
+        if self._positions:
+            return None
+
+        # Check if price has dropped enough from recent high
+        deviation = (self._recent_high - close) / self._recent_high
+        if deviation < self._price_deviation_pct:
+            return None
+
+        # Cost check
+        if current_balance < self._base_order_size:
+            return None
+
+        # Calculate TP and SL
+        take_profit = close * (Decimal("1") + self._take_profit_pct)
+        # SL after all safety orders would be hit
+        total_drop = self._price_deviation_pct + (
+            self._safety_step_pct * self._max_safety_orders
+        )
+        stop_loss = close * (Decimal("1") - total_drop)
+
+        return BaseSignal(
+            direction=SignalDirection.LONG,
+            entry_price=close,
+            stop_loss=stop_loss,
+            take_profit=take_profit,
+            confidence=0.7,
+            timestamp=datetime.now(timezone.utc),
+            strategy_type="dca",
+            signal_reason="dca_price_drop",
+            risk_reward_ratio=float(self._take_profit_pct / total_drop),
+            metadata={
+                "deviation_pct": float(deviation),
+                "safety_orders_available": self._max_safety_orders,
+            },
+        )
+
+    def open_position(self, signal: BaseSignal, position_size: Decimal) -> str:
+        pos_id = str(uuid.uuid4())[:8]
+        self._positions[pos_id] = {
+            "direction": signal.direction,
+            "entry_price": signal.entry_price,
+            "avg_price": signal.entry_price,
+            "stop_loss": signal.stop_loss,
+            "take_profit": signal.take_profit,
+            "size": position_size,
+            "total_invested": position_size * signal.entry_price,
+            "safety_orders_filled": 0,
+            "entry_time": datetime.now(timezone.utc),
+            "current_price": signal.entry_price,
+        }
+        return pos_id
+
+    def update_positions(
+        self, current_price: Decimal, df: pd.DataFrame
+    ) -> list[tuple[str, ExitReason]]:
+        exits: list[tuple[str, ExitReason]] = []
+        self._current_price = current_price
+
+        for pos_id, pos in list(self._positions.items()):
+            pos["current_price"] = current_price
+
+            # Check take profit (based on average price)
+            tp_price = pos["avg_price"] * (Decimal("1") + self._take_profit_pct)
+            if current_price >= tp_price:
+                exits.append((pos_id, ExitReason.TAKE_PROFIT))
+                continue
+
+            # Check stop loss
+            if current_price <= pos["stop_loss"]:
+                exits.append((pos_id, ExitReason.STOP_LOSS))
+                continue
+
+            # Check safety order triggers (DCA averaging down)
+            safety_filled = pos["safety_orders_filled"]
+            if safety_filled < self._max_safety_orders:
+                next_level_drop = self._safety_step_pct * (safety_filled + 1)
+                trigger_price = pos["entry_price"] * (Decimal("1") - next_level_drop)
+                if current_price <= trigger_price:
+                    # Fill safety order: average down
+                    old_total = pos["total_invested"]
+                    safety_invest = self._safety_order_size * current_price
+                    new_total = old_total + safety_invest
+                    old_qty = pos["size"]
+                    new_qty = old_qty + self._safety_order_size
+                    pos["size"] = new_qty
+                    pos["total_invested"] = new_total
+                    pos["avg_price"] = new_total / new_qty if new_qty > 0 else pos["avg_price"]
+                    pos["safety_orders_filled"] = safety_filled + 1
+                    # Update TP based on new average
+                    pos["take_profit"] = pos["avg_price"] * (Decimal("1") + self._take_profit_pct)
+
+        return exits
+
+    def close_position(
+        self, position_id: str, exit_reason: ExitReason, exit_price: Decimal
+    ) -> None:
+        pos = self._positions.pop(position_id, None)
+        if not pos:
+            return
+
+        pnl = (exit_price - pos["avg_price"]) * pos["size"]
+        self._closed_trades.append({
+            "position_id": position_id,
+            "entry_price": pos["entry_price"],
+            "avg_price": pos["avg_price"],
+            "exit_price": exit_price,
+            "size": pos["size"],
+            "pnl": pnl,
+            "exit_reason": exit_reason.value,
+            "safety_orders_filled": pos["safety_orders_filled"],
+            "entry_time": pos["entry_time"],
+            "exit_time": datetime.now(timezone.utc),
+        })
+
+    def get_active_positions(self) -> list[PositionInfo]:
+        result = []
+        for pos_id, pos in self._positions.items():
+            pnl = (pos["current_price"] - pos["avg_price"]) * pos["size"]
+            result.append(
+                PositionInfo(
+                    position_id=pos_id,
+                    direction=pos["direction"],
+                    entry_price=pos["avg_price"],
+                    current_price=pos["current_price"],
+                    size=pos["size"],
+                    stop_loss=pos["stop_loss"],
+                    take_profit=pos["take_profit"],
+                    unrealized_pnl=pnl,
+                    entry_time=pos["entry_time"],
+                    strategy_type="dca",
+                    metadata={
+                        "safety_orders_filled": pos["safety_orders_filled"],
+                    },
+                )
+            )
+        return result
+
+    def get_performance(self) -> StrategyPerformance:
+        total = len(self._closed_trades)
+        if total == 0:
+            return StrategyPerformance()
+
+        winners = [t for t in self._closed_trades if t["pnl"] > 0]
+        losers = [t for t in self._closed_trades if t["pnl"] <= 0]
+        total_pnl = sum(t["pnl"] for t in self._closed_trades)
+
+        return StrategyPerformance(
+            total_trades=total,
+            winning_trades=len(winners),
+            losing_trades=len(losers),
+            win_rate=len(winners) / total if total > 0 else 0.0,
+            total_pnl=total_pnl,
+            avg_trade_pnl=total_pnl / total if total > 0 else Decimal("0"),
+            metadata={
+                "avg_safety_orders": sum(
+                    t["safety_orders_filled"] for t in self._closed_trades
+                )
+                / total
+                if total > 0
+                else 0,
+            },
+        )
+
+    def reset(self) -> None:
+        self._positions.clear()
+        self._closed_trades.clear()
+        self._last_analysis = None
+        self._recent_high = Decimal("0")
+        self._current_price = Decimal("0")

--- a/bot/strategies/grid_adapter.py
+++ b/bot/strategies/grid_adapter.py
@@ -1,0 +1,283 @@
+"""
+Grid Strategy Adapter — Wraps GridEngine to conform to BaseStrategy interface.
+
+Translates grid-level order logic into the unified signal/position lifecycle
+for use with BacktestEngine and StrategyComparison.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+
+from bot.core.grid_engine import GridEngine, GridOrder
+from bot.strategies.base import (
+    BaseMarketAnalysis,
+    BaseSignal,
+    BaseStrategy,
+    ExitReason,
+    PositionInfo,
+    SignalDirection,
+    StrategyPerformance,
+)
+from bot.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class GridAdapter(BaseStrategy):
+    """
+    Adapter that wraps GridEngine to conform to BaseStrategy interface.
+
+    For backtesting, simulates grid trading as a series of buy/sell positions:
+    - analyze_market: computes price range and volatility
+    - generate_signal: buys when price near a grid buy level
+    - update_positions: sells when price hits grid sell level (TP)
+    """
+
+    def __init__(
+        self,
+        symbol: str = "BTC/USDT",
+        num_levels: int = 10,
+        amount_per_grid: Decimal = Decimal("100"),
+        profit_per_grid: Decimal = Decimal("0.005"),
+        grid_range_pct: Decimal = Decimal("0.05"),
+        name: str = "grid-default",
+    ) -> None:
+        self._symbol = symbol
+        self._name = name
+        self._num_levels = num_levels
+        self._amount_per_grid = amount_per_grid
+        self._profit_per_grid = profit_per_grid
+        self._grid_range_pct = grid_range_pct
+
+        self._grid_engine: GridEngine | None = None
+        self._grid_levels: list[Decimal] = []
+        self._last_analysis: BaseMarketAnalysis | None = None
+
+        # Position tracking
+        self._positions: dict[str, dict[str, Any]] = {}
+        self._closed_trades: list[dict[str, Any]] = []
+        self._current_price = Decimal("0")
+
+    def get_strategy_name(self) -> str:
+        return self._name
+
+    def get_strategy_type(self) -> str:
+        return "grid"
+
+    def analyze_market(self, *dfs: pd.DataFrame) -> BaseMarketAnalysis:
+        """Analyze market to set up grid bounds from recent price action."""
+        df = dfs[-1] if dfs else pd.DataFrame()
+
+        if df.empty or len(df) < 5:
+            return BaseMarketAnalysis(
+                trend="unknown",
+                trend_strength=0.0,
+                volatility=0.0,
+                timestamp=datetime.now(timezone.utc),
+                strategy_type="grid",
+            )
+
+        close = df["close"].values
+        self._current_price = Decimal(str(close[-1]))
+
+        # Calculate volatility (ATR-like)
+        high = df["high"].values
+        low = df["low"].values
+        tr = high - low
+        atr = float(np.mean(tr[-14:])) if len(tr) >= 14 else float(np.mean(tr))
+        volatility = atr / float(close[-1]) if close[-1] > 0 else 0.0
+
+        # Determine grid bounds based on recent range
+        current = self._current_price
+        half_range = current * self._grid_range_pct
+        upper = current + half_range
+        lower = current - half_range
+
+        # Initialize or re-initialize grid engine
+        self._grid_engine = GridEngine(
+            symbol=self._symbol,
+            upper_price=upper,
+            lower_price=lower,
+            grid_levels=self._num_levels,
+            amount_per_grid=self._amount_per_grid,
+            profit_per_grid=self._profit_per_grid,
+        )
+        self._grid_levels = self._grid_engine.calculate_grid_levels()
+
+        # Trend: grid works best in sideways
+        price_change = (close[-1] - close[0]) / close[0] if close[0] > 0 else 0.0
+        if abs(price_change) < 0.02:
+            trend = "sideways"
+            trend_strength = 0.3
+        elif price_change > 0:
+            trend = "bullish"
+            trend_strength = min(abs(price_change) * 10, 1.0)
+        else:
+            trend = "bearish"
+            trend_strength = min(abs(price_change) * 10, 1.0)
+
+        self._last_analysis = BaseMarketAnalysis(
+            trend=trend,
+            trend_strength=trend_strength,
+            volatility=volatility,
+            timestamp=datetime.now(timezone.utc),
+            strategy_type="grid",
+            details={
+                "upper_price": float(upper),
+                "lower_price": float(lower),
+                "grid_levels": len(self._grid_levels),
+                "atr": atr,
+            },
+        )
+        return self._last_analysis
+
+    def generate_signal(
+        self, df: pd.DataFrame, current_balance: Decimal
+    ) -> Optional[BaseSignal]:
+        """Generate buy signal when price is near a grid buy level."""
+        if not self._grid_levels or df.empty:
+            return None
+
+        close = Decimal(str(df["close"].iloc[-1]))
+        self._current_price = close
+
+        # Find nearest buy level below current price
+        buy_levels = [l for l in self._grid_levels if l < close]
+        if not buy_levels:
+            return None
+
+        nearest_buy = max(buy_levels)
+        distance = abs(close - nearest_buy) / close
+
+        # Only signal if price is very close to a buy level (within 0.5%)
+        if distance > Decimal("0.005"):
+            return None
+
+        # Check we don't already have a position at this level
+        for pos in self._positions.values():
+            if abs(pos["entry_price"] - nearest_buy) / nearest_buy < Decimal("0.003"):
+                return None
+
+        # Cost check
+        if current_balance < self._amount_per_grid:
+            return None
+
+        sell_target = nearest_buy * (Decimal("1") + self._profit_per_grid)
+        stop_loss = nearest_buy * (Decimal("1") - self._grid_range_pct)
+
+        return BaseSignal(
+            direction=SignalDirection.LONG,
+            entry_price=close,
+            stop_loss=stop_loss,
+            take_profit=sell_target,
+            confidence=0.6,
+            timestamp=datetime.now(timezone.utc),
+            strategy_type="grid",
+            signal_reason="grid_buy_level",
+            risk_reward_ratio=float(self._profit_per_grid / self._grid_range_pct),
+            metadata={"grid_level": float(nearest_buy)},
+        )
+
+    def open_position(self, signal: BaseSignal, position_size: Decimal) -> str:
+        pos_id = str(uuid.uuid4())[:8]
+        self._positions[pos_id] = {
+            "direction": signal.direction,
+            "entry_price": signal.entry_price,
+            "stop_loss": signal.stop_loss,
+            "take_profit": signal.take_profit,
+            "size": position_size,
+            "entry_time": datetime.now(timezone.utc),
+            "current_price": signal.entry_price,
+        }
+        return pos_id
+
+    def update_positions(
+        self, current_price: Decimal, df: pd.DataFrame
+    ) -> list[tuple[str, ExitReason]]:
+        exits: list[tuple[str, ExitReason]] = []
+        self._current_price = current_price
+
+        for pos_id, pos in list(self._positions.items()):
+            pos["current_price"] = current_price
+            if current_price >= pos["take_profit"]:
+                exits.append((pos_id, ExitReason.TAKE_PROFIT))
+            elif current_price <= pos["stop_loss"]:
+                exits.append((pos_id, ExitReason.STOP_LOSS))
+
+        return exits
+
+    def close_position(
+        self, position_id: str, exit_reason: ExitReason, exit_price: Decimal
+    ) -> None:
+        pos = self._positions.pop(position_id, None)
+        if not pos:
+            return
+
+        pnl = (exit_price - pos["entry_price"]) * pos["size"] / pos["entry_price"]
+        self._closed_trades.append({
+            "position_id": position_id,
+            "entry_price": pos["entry_price"],
+            "exit_price": exit_price,
+            "size": pos["size"],
+            "pnl": pnl,
+            "exit_reason": exit_reason.value,
+            "entry_time": pos["entry_time"],
+            "exit_time": datetime.now(timezone.utc),
+        })
+
+    def get_active_positions(self) -> list[PositionInfo]:
+        result = []
+        for pos_id, pos in self._positions.items():
+            pnl = (
+                (pos["current_price"] - pos["entry_price"])
+                * pos["size"]
+                / pos["entry_price"]
+                if pos["entry_price"] > 0
+                else Decimal("0")
+            )
+            result.append(
+                PositionInfo(
+                    position_id=pos_id,
+                    direction=pos["direction"],
+                    entry_price=pos["entry_price"],
+                    current_price=pos["current_price"],
+                    size=pos["size"],
+                    stop_loss=pos["stop_loss"],
+                    take_profit=pos["take_profit"],
+                    unrealized_pnl=pnl,
+                    entry_time=pos["entry_time"],
+                    strategy_type="grid",
+                )
+            )
+        return result
+
+    def get_performance(self) -> StrategyPerformance:
+        total = len(self._closed_trades)
+        if total == 0:
+            return StrategyPerformance()
+
+        winners = [t for t in self._closed_trades if t["pnl"] > 0]
+        losers = [t for t in self._closed_trades if t["pnl"] <= 0]
+        total_pnl = sum(t["pnl"] for t in self._closed_trades)
+
+        return StrategyPerformance(
+            total_trades=total,
+            winning_trades=len(winners),
+            losing_trades=len(losers),
+            win_rate=len(winners) / total if total > 0 else 0.0,
+            total_pnl=total_pnl,
+            avg_trade_pnl=total_pnl / total if total > 0 else Decimal("0"),
+        )
+
+    def reset(self) -> None:
+        self._grid_engine = None
+        self._grid_levels = []
+        self._positions.clear()
+        self._closed_trades.clear()
+        self._last_analysis = None
+        self._current_price = Decimal("0")

--- a/bot/tests/backtesting/__init__.py
+++ b/bot/tests/backtesting/__init__.py
@@ -4,6 +4,7 @@ from .backtesting_engine import BacktestingEngine
 from .market_simulator import MarketSimulator
 from .multi_tf_data_loader import MultiTimeframeData, MultiTimeframeDataLoader
 from .multi_tf_engine import MultiTFBacktestConfig, MultiTimeframeBacktestEngine
+from .strategy_comparison import StrategyComparison, StrategyComparisonResult
 from .test_data import HistoricalDataProvider
 
 __all__ = [
@@ -14,4 +15,6 @@ __all__ = [
     "MultiTimeframeData",
     "MultiTimeframeBacktestEngine",
     "MultiTFBacktestConfig",
+    "StrategyComparison",
+    "StrategyComparisonResult",
 ]

--- a/bot/tests/backtesting/strategy_comparison.py
+++ b/bot/tests/backtesting/strategy_comparison.py
@@ -1,0 +1,199 @@
+"""
+Strategy Comparison — Run multiple strategies on same data and compare results.
+
+Produces comparative reports with rankings by various metrics.
+
+Usage:
+    comparison = StrategyComparison(config=MultiTFBacktestConfig())
+    results = await comparison.run([strategy1, strategy2], data)
+    report = comparison.generate_report(results)
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from bot.strategies.base import BaseStrategy
+from bot.tests.backtesting.backtesting_engine import BacktestResult
+from bot.tests.backtesting.multi_tf_data_loader import (
+    MultiTimeframeData,
+    MultiTimeframeDataLoader,
+)
+from bot.tests.backtesting.multi_tf_engine import (
+    MultiTFBacktestConfig,
+    MultiTimeframeBacktestEngine,
+)
+
+
+@dataclass
+class StrategyComparisonResult:
+    """Results from comparing multiple strategies."""
+
+    results: dict[str, BacktestResult]
+    rankings: dict[str, list[str]]
+    summary: dict[str, dict[str, Any]]
+
+    def get_winner(self, metric: str = "total_return_pct") -> str | None:
+        """Get the strategy name that ranks first for a given metric."""
+        ranking = self.rankings.get(metric, [])
+        return ranking[0] if ranking else None
+
+
+class StrategyComparison:
+    """
+    Run multiple strategies on the same market data and compare performance.
+    """
+
+    def __init__(self, config: MultiTFBacktestConfig | None = None) -> None:
+        self.config = config or MultiTFBacktestConfig()
+
+    async def run(
+        self,
+        strategies: list[BaseStrategy],
+        data: MultiTimeframeData,
+    ) -> StrategyComparisonResult:
+        """
+        Run all strategies on the same data and compare results.
+
+        Args:
+            strategies: List of BaseStrategy implementations to compare.
+            data: Shared MultiTimeframeData for all strategies.
+
+        Returns:
+            StrategyComparisonResult with results, rankings, and summary.
+        """
+        results: dict[str, BacktestResult] = {}
+
+        for strategy in strategies:
+            engine = MultiTimeframeBacktestEngine(config=self.config)
+            result = await engine.run(strategy, data)
+            results[strategy.get_strategy_name()] = result
+
+        rankings = self._compute_rankings(results)
+        summary = self._compute_summary(results)
+
+        return StrategyComparisonResult(
+            results=results,
+            rankings=rankings,
+            summary=summary,
+        )
+
+    async def run_with_generated_data(
+        self,
+        strategies: list[BaseStrategy],
+        start_date: datetime,
+        end_date: datetime,
+        trend: str = "up",
+        base_price: Decimal = Decimal("45000"),
+    ) -> StrategyComparisonResult:
+        """Convenience: generate data and run comparison."""
+        loader = MultiTimeframeDataLoader()
+        data = loader.load(
+            symbol=self.config.symbol,
+            start_date=start_date,
+            end_date=end_date,
+            trend=trend,
+            base_price=base_price,
+        )
+        return await self.run(strategies, data)
+
+    def _compute_rankings(
+        self, results: dict[str, BacktestResult]
+    ) -> dict[str, list[str]]:
+        """Compute rankings for each metric (higher is better, except drawdown)."""
+        if not results:
+            return {}
+
+        metrics = {
+            "total_return_pct": True,  # higher is better
+            "win_rate": True,
+            "total_trades": True,
+            "max_drawdown_pct": False,  # lower is better
+        }
+
+        rankings: dict[str, list[str]] = {}
+
+        for metric, higher_is_better in metrics.items():
+            items = []
+            for name, result in results.items():
+                value = getattr(result, metric, Decimal("0"))
+                items.append((name, float(value)))
+
+            items.sort(key=lambda x: x[1], reverse=higher_is_better)
+            rankings[metric] = [name for name, _ in items]
+
+        # Sharpe ratio ranking (higher is better, handle None)
+        sharpe_items = []
+        for name, result in results.items():
+            sr = result.sharpe_ratio
+            sharpe_items.append((name, float(sr) if sr is not None else float("-inf")))
+        sharpe_items.sort(key=lambda x: x[1], reverse=True)
+        rankings["sharpe_ratio"] = [name for name, _ in sharpe_items]
+
+        return rankings
+
+    def _compute_summary(
+        self, results: dict[str, BacktestResult]
+    ) -> dict[str, dict[str, Any]]:
+        """Compute summary statistics for each strategy."""
+        summary: dict[str, dict[str, Any]] = {}
+
+        for name, result in results.items():
+            summary[name] = {
+                "total_return_pct": float(result.total_return_pct),
+                "final_balance": float(result.final_balance),
+                "total_trades": result.total_trades,
+                "win_rate": float(result.win_rate),
+                "max_drawdown_pct": float(result.max_drawdown_pct),
+                "sharpe_ratio": float(result.sharpe_ratio)
+                if result.sharpe_ratio is not None
+                else None,
+                "avg_profit_per_trade": float(result.avg_profit_per_trade),
+                "buy_orders": result.total_buy_orders,
+                "sell_orders": result.total_sell_orders,
+            }
+
+        return summary
+
+    @staticmethod
+    def format_report(comparison: StrategyComparisonResult) -> str:
+        """Format comparison result as a human-readable report."""
+        lines = []
+        lines.append("=" * 70)
+        lines.append("STRATEGY COMPARISON REPORT")
+        lines.append("=" * 70)
+
+        # Summary table
+        lines.append("\nPerformance Summary:")
+        lines.append("-" * 70)
+        header = f"{'Strategy':<20} {'Return%':>10} {'Trades':>8} {'Win%':>8} {'DD%':>8} {'Sharpe':>8}"
+        lines.append(header)
+        lines.append("-" * 70)
+
+        for name, stats in comparison.summary.items():
+            sharpe_str = f"{stats['sharpe_ratio']:.2f}" if stats["sharpe_ratio"] is not None else "N/A"
+            line = (
+                f"{name:<20} "
+                f"{stats['total_return_pct']:>9.2f}% "
+                f"{stats['total_trades']:>8d} "
+                f"{stats['win_rate']:>7.1f}% "
+                f"{stats['max_drawdown_pct']:>7.2f}% "
+                f"{sharpe_str:>8s}"
+            )
+            lines.append(line)
+
+        # Rankings
+        lines.append("\nRankings:")
+        lines.append("-" * 70)
+        for metric, ranking in comparison.rankings.items():
+            ranked = ", ".join(f"{i+1}.{n}" for i, n in enumerate(ranking))
+            lines.append(f"  {metric}: {ranked}")
+
+        # Winner
+        winner = comparison.get_winner("total_return_pct")
+        if winner:
+            lines.append(f"\nBest overall return: {winner}")
+
+        lines.append("=" * 70)
+        return "\n".join(lines)

--- a/bot/tests/backtesting/test_multi_strategy_backtesting.py
+++ b/bot/tests/backtesting/test_multi_strategy_backtesting.py
@@ -1,0 +1,549 @@
+"""Tests for multi-strategy backtesting — Issue #173."""
+
+from datetime import datetime
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+
+from bot.strategies.base import (
+    BaseMarketAnalysis,
+    BaseSignal,
+    ExitReason,
+    SignalDirection,
+    StrategyPerformance,
+)
+from bot.strategies.dca_adapter import DCAAdapter
+from bot.strategies.grid_adapter import GridAdapter
+from bot.tests.backtesting.backtesting_engine import BacktestResult
+from bot.tests.backtesting.multi_tf_data_loader import (
+    MultiTimeframeData,
+    MultiTimeframeDataLoader,
+)
+from bot.tests.backtesting.multi_tf_engine import (
+    MultiTFBacktestConfig,
+    MultiTimeframeBacktestEngine,
+)
+from bot.tests.backtesting.strategy_comparison import (
+    StrategyComparison,
+    StrategyComparisonResult,
+)
+from tests.strategies.test_base_strategy import ConcreteStrategy, _make_ohlcv
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def loader():
+    return MultiTimeframeDataLoader()
+
+
+@pytest.fixture
+def data_7days(loader):
+    return loader.load(
+        symbol="BTC/USDT",
+        start_date=datetime(2024, 1, 1),
+        end_date=datetime(2024, 1, 8),
+        trend="up",
+    )
+
+
+@pytest.fixture
+def config():
+    return MultiTFBacktestConfig(
+        symbol="BTC/USDT",
+        initial_balance=Decimal("10000"),
+        warmup_bars=20,
+    )
+
+
+@pytest.fixture
+def engine(config):
+    return MultiTimeframeBacktestEngine(config=config)
+
+
+# =============================================================================
+# GridAdapter Unit Tests
+# =============================================================================
+
+
+class TestGridAdapterUnit:
+    """Unit tests for GridAdapter."""
+
+    def test_strategy_name_and_type(self):
+        adapter = GridAdapter(name="grid-test")
+        assert adapter.get_strategy_name() == "grid-test"
+        assert adapter.get_strategy_type() == "grid"
+
+    def test_analyze_market(self):
+        adapter = GridAdapter()
+        df = _make_ohlcv([100 + i * 0.1 for i in range(50)])
+        result = adapter.analyze_market(df)
+        assert isinstance(result, BaseMarketAnalysis)
+        assert result.strategy_type == "grid"
+        assert "upper_price" in result.details
+        assert "lower_price" in result.details
+
+    def test_analyze_market_empty_df(self):
+        adapter = GridAdapter()
+        result = adapter.analyze_market(pd.DataFrame())
+        assert result.trend == "unknown"
+
+    def test_generate_signal_requires_analysis(self):
+        adapter = GridAdapter()
+        df = _make_ohlcv([100, 101, 102])
+        # No analysis yet, no grid levels
+        signal = adapter.generate_signal(df, Decimal("10000"))
+        assert signal is None
+
+    def test_open_and_close_position(self):
+        adapter = GridAdapter()
+        signal = BaseSignal(
+            direction=SignalDirection.LONG,
+            entry_price=Decimal("100"),
+            stop_loss=Decimal("95"),
+            take_profit=Decimal("105"),
+            confidence=0.6,
+            timestamp=datetime(2024, 1, 1),
+            strategy_type="grid",
+        )
+        pos_id = adapter.open_position(signal, Decimal("10"))
+        assert len(adapter.get_active_positions()) == 1
+
+        adapter.close_position(pos_id, ExitReason.TAKE_PROFIT, Decimal("105"))
+        assert len(adapter.get_active_positions()) == 0
+        assert adapter.get_performance().total_trades == 1
+
+    def test_update_positions_take_profit(self):
+        adapter = GridAdapter()
+        signal = BaseSignal(
+            direction=SignalDirection.LONG,
+            entry_price=Decimal("100"),
+            stop_loss=Decimal("95"),
+            take_profit=Decimal("105"),
+            confidence=0.6,
+            timestamp=datetime(2024, 1, 1),
+            strategy_type="grid",
+        )
+        adapter.open_position(signal, Decimal("10"))
+        df = _make_ohlcv([100])
+
+        exits = adapter.update_positions(Decimal("106"), df)
+        assert len(exits) == 1
+        assert exits[0][1] == ExitReason.TAKE_PROFIT
+
+    def test_update_positions_stop_loss(self):
+        adapter = GridAdapter()
+        signal = BaseSignal(
+            direction=SignalDirection.LONG,
+            entry_price=Decimal("100"),
+            stop_loss=Decimal("95"),
+            take_profit=Decimal("105"),
+            confidence=0.6,
+            timestamp=datetime(2024, 1, 1),
+            strategy_type="grid",
+        )
+        adapter.open_position(signal, Decimal("10"))
+        df = _make_ohlcv([100])
+
+        exits = adapter.update_positions(Decimal("94"), df)
+        assert len(exits) == 1
+        assert exits[0][1] == ExitReason.STOP_LOSS
+
+    def test_reset(self):
+        adapter = GridAdapter()
+        signal = BaseSignal(
+            direction=SignalDirection.LONG,
+            entry_price=Decimal("100"),
+            stop_loss=Decimal("95"),
+            take_profit=Decimal("105"),
+            confidence=0.6,
+            timestamp=datetime(2024, 1, 1),
+            strategy_type="grid",
+        )
+        adapter.open_position(signal, Decimal("10"))
+        adapter.reset()
+        assert len(adapter.get_active_positions()) == 0
+
+    def test_performance_empty(self):
+        adapter = GridAdapter()
+        perf = adapter.get_performance()
+        assert perf.total_trades == 0
+
+
+# =============================================================================
+# DCAAdapter Unit Tests
+# =============================================================================
+
+
+class TestDCAAdapterUnit:
+    """Unit tests for DCAAdapter."""
+
+    def test_strategy_name_and_type(self):
+        adapter = DCAAdapter(name="dca-test")
+        assert adapter.get_strategy_name() == "dca-test"
+        assert adapter.get_strategy_type() == "dca"
+
+    def test_analyze_market(self):
+        adapter = DCAAdapter()
+        df = _make_ohlcv([100 - i * 0.1 for i in range(50)])
+        result = adapter.analyze_market(df)
+        assert isinstance(result, BaseMarketAnalysis)
+        assert result.strategy_type == "dca"
+        assert "recent_high" in result.details
+        assert "deviation_from_high" in result.details
+
+    def test_analyze_market_empty_df(self):
+        adapter = DCAAdapter()
+        result = adapter.analyze_market(pd.DataFrame())
+        assert result.trend == "unknown"
+
+    def test_generate_signal_no_drop(self):
+        adapter = DCAAdapter()
+        # Prices going up — no DCA entry
+        prices = [100 + i for i in range(50)]
+        df = _make_ohlcv(prices)
+        adapter.analyze_market(df)
+        signal = adapter.generate_signal(df, Decimal("10000"))
+        assert signal is None
+
+    def test_open_and_close_position(self):
+        adapter = DCAAdapter()
+        signal = BaseSignal(
+            direction=SignalDirection.LONG,
+            entry_price=Decimal("100"),
+            stop_loss=Decimal("80"),
+            take_profit=Decimal("105"),
+            confidence=0.7,
+            timestamp=datetime(2024, 1, 1),
+            strategy_type="dca",
+        )
+        pos_id = adapter.open_position(signal, Decimal("10"))
+        assert len(adapter.get_active_positions()) == 1
+
+        adapter.close_position(pos_id, ExitReason.TAKE_PROFIT, Decimal("105"))
+        assert len(adapter.get_active_positions()) == 0
+
+    def test_safety_order_averaging(self):
+        """DCA should average down when price drops by safety step."""
+        adapter = DCAAdapter(
+            safety_step_pct=Decimal("0.02"),
+            safety_order_size=Decimal("200"),
+        )
+        signal = BaseSignal(
+            direction=SignalDirection.LONG,
+            entry_price=Decimal("100"),
+            stop_loss=Decimal("80"),
+            take_profit=Decimal("102"),
+            confidence=0.7,
+            timestamp=datetime(2024, 1, 1),
+            strategy_type="dca",
+        )
+        adapter.open_position(signal, Decimal("10"))
+        df = _make_ohlcv([100])
+
+        # Drop price by 2% to trigger first safety order
+        adapter.update_positions(Decimal("98"), df)
+
+        positions = adapter.get_active_positions()
+        assert len(positions) == 1
+        # Safety order should have increased position size
+        assert positions[0].metadata.get("safety_orders_filled") == 1
+
+    def test_reset(self):
+        adapter = DCAAdapter()
+        signal = BaseSignal(
+            direction=SignalDirection.LONG,
+            entry_price=Decimal("100"),
+            stop_loss=Decimal("80"),
+            take_profit=Decimal("105"),
+            confidence=0.7,
+            timestamp=datetime(2024, 1, 1),
+            strategy_type="dca",
+        )
+        adapter.open_position(signal, Decimal("10"))
+        adapter.reset()
+        assert len(adapter.get_active_positions()) == 0
+
+    def test_performance_with_trades(self):
+        adapter = DCAAdapter()
+        signal = BaseSignal(
+            direction=SignalDirection.LONG,
+            entry_price=Decimal("100"),
+            stop_loss=Decimal("80"),
+            take_profit=Decimal("105"),
+            confidence=0.7,
+            timestamp=datetime(2024, 1, 1),
+            strategy_type="dca",
+        )
+        adapter.open_position(signal, Decimal("10"))
+        adapter.close_position("nonexistent", ExitReason.TAKE_PROFIT, Decimal("105"))
+        # That was a non-existent position, so performance should still be 0
+        assert adapter.get_performance().total_trades == 0
+
+
+# =============================================================================
+# Grid Backtest Integration Tests
+# =============================================================================
+
+
+class TestGridBacktestIntegration:
+    """Test GridAdapter through the backtest engine."""
+
+    async def test_grid_backtest_runs(self, engine, data_7days):
+        strategy = GridAdapter(name="grid-backtest")
+        result = await engine.run(strategy, data_7days)
+        assert isinstance(result, BacktestResult)
+        assert result.strategy_name == "grid-backtest"
+        assert len(result.equity_curve) > 0
+
+    async def test_grid_backtest_initial_balance(self, engine, data_7days):
+        strategy = GridAdapter(name="grid-test")
+        result = await engine.run(strategy, data_7days)
+        assert result.initial_balance == Decimal("10000")
+
+
+# =============================================================================
+# DCA Backtest Integration Tests
+# =============================================================================
+
+
+class TestDCABacktestIntegration:
+    """Test DCAAdapter through the backtest engine."""
+
+    async def test_dca_backtest_runs(self, engine, data_7days):
+        strategy = DCAAdapter(name="dca-backtest")
+        result = await engine.run(strategy, data_7days)
+        assert isinstance(result, BacktestResult)
+        assert result.strategy_name == "dca-backtest"
+        assert len(result.equity_curve) > 0
+
+    async def test_dca_backtest_initial_balance(self, engine, data_7days):
+        strategy = DCAAdapter(name="dca-test")
+        result = await engine.run(strategy, data_7days)
+        assert result.initial_balance == Decimal("10000")
+
+
+# =============================================================================
+# SMC Integration (with patched config)
+# =============================================================================
+
+
+class TestSMCBacktestIntegration:
+    """Test SMCStrategyAdapter through multi-TF engine."""
+
+    async def test_smc_backtest(self):
+        from bot.strategies.smc.config import SMCConfig
+        from bot.strategies.smc_adapter import SMCStrategyAdapter
+
+        smc_config = SMCConfig()
+        smc_config.risk_per_trade_pct = smc_config.risk_per_trade
+        smc_config.max_position_size_usd = smc_config.max_position_size
+
+        config = MultiTFBacktestConfig(
+            initial_balance=Decimal("10000"),
+            warmup_bars=60,
+        )
+        engine = MultiTimeframeBacktestEngine(config=config)
+        strategy = SMCStrategyAdapter(
+            config=smc_config,
+            account_balance=Decimal("10000"),
+            name="smc-backtest",
+        )
+
+        result = await engine.run_with_generated_data(
+            strategy=strategy,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 5),
+            trend="up",
+        )
+
+        assert result.strategy_name == "smc-backtest"
+        assert len(result.equity_curve) > 0
+
+
+# =============================================================================
+# TrendFollower Integration
+# =============================================================================
+
+
+class TestTrendFollowerBacktestIntegration:
+    """Test TrendFollowerAdapter through multi-TF engine."""
+
+    async def test_trend_follower_backtest(self, config):
+        from bot.strategies.trend_follower_adapter import TrendFollowerAdapter
+
+        config.warmup_bars = 60
+        engine = MultiTimeframeBacktestEngine(config=config)
+        strategy = TrendFollowerAdapter(
+            initial_capital=Decimal("10000"),
+            name="tf-backtest",
+            log_trades=False,
+        )
+
+        result = await engine.run_with_generated_data(
+            strategy=strategy,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 8),
+            trend="up",
+        )
+
+        assert result.strategy_name == "tf-backtest"
+        assert len(result.equity_curve) > 0
+
+
+# =============================================================================
+# Strategy Comparison Tests
+# =============================================================================
+
+
+class TestStrategyComparison:
+    """Tests for StrategyComparison utility."""
+
+    async def test_comparison_runs(self, data_7days, config):
+        comparison = StrategyComparison(config=config)
+        strategies = [
+            ConcreteStrategy(),
+            GridAdapter(name="grid-compare"),
+            DCAAdapter(name="dca-compare"),
+        ]
+
+        result = await comparison.run(strategies, data_7days)
+        assert isinstance(result, StrategyComparisonResult)
+        assert "test-concrete" in result.results
+        assert "grid-compare" in result.results
+        assert "dca-compare" in result.results
+
+    async def test_comparison_rankings(self, data_7days, config):
+        comparison = StrategyComparison(config=config)
+        strategies = [
+            ConcreteStrategy(),
+            GridAdapter(name="grid-rank"),
+        ]
+
+        result = await comparison.run(strategies, data_7days)
+        assert "total_return_pct" in result.rankings
+        assert "win_rate" in result.rankings
+        assert "sharpe_ratio" in result.rankings
+        assert "max_drawdown_pct" in result.rankings
+
+    async def test_comparison_summary(self, data_7days, config):
+        comparison = StrategyComparison(config=config)
+        strategies = [ConcreteStrategy()]
+
+        result = await comparison.run(strategies, data_7days)
+        assert "test-concrete" in result.summary
+        summary = result.summary["test-concrete"]
+        assert "total_return_pct" in summary
+        assert "final_balance" in summary
+        assert "total_trades" in summary
+        assert "win_rate" in summary
+
+    async def test_comparison_get_winner(self, data_7days, config):
+        comparison = StrategyComparison(config=config)
+        strategies = [
+            ConcreteStrategy(),
+            GridAdapter(name="grid-winner"),
+        ]
+
+        result = await comparison.run(strategies, data_7days)
+        winner = result.get_winner("total_return_pct")
+        assert winner is not None
+        assert winner in ("test-concrete", "grid-winner")
+
+    async def test_comparison_format_report(self, data_7days, config):
+        comparison = StrategyComparison(config=config)
+        strategies = [
+            ConcreteStrategy(),
+            GridAdapter(name="grid-report"),
+            DCAAdapter(name="dca-report"),
+        ]
+
+        result = await comparison.run(strategies, data_7days)
+        report = StrategyComparison.format_report(result)
+        assert "STRATEGY COMPARISON REPORT" in report
+        assert "test-concrete" in report
+        assert "grid-report" in report
+        assert "dca-report" in report
+        assert "Rankings:" in report
+
+    async def test_comparison_with_generated_data(self):
+        config = MultiTFBacktestConfig(
+            initial_balance=Decimal("10000"),
+            warmup_bars=20,
+        )
+        comparison = StrategyComparison(config=config)
+        strategies = [
+            ConcreteStrategy(),
+            GridAdapter(name="grid-gen"),
+        ]
+
+        result = await comparison.run_with_generated_data(
+            strategies=strategies,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 8),
+            trend="up",
+        )
+
+        assert len(result.results) == 2
+
+
+# =============================================================================
+# Multi-Trend Comparison Tests
+# =============================================================================
+
+
+class TestMultiTrendComparison:
+    """Test strategies across different market conditions."""
+
+    async def test_uptrend_vs_downtrend(self, config):
+        loader = MultiTimeframeDataLoader()
+        data_up = loader.load(
+            "BTC/USDT", datetime(2024, 1, 1), datetime(2024, 1, 8), trend="up"
+        )
+        data_down = loader.load(
+            "BTC/USDT", datetime(2024, 1, 1), datetime(2024, 1, 8), trend="down"
+        )
+
+        strategy = GridAdapter(name="grid-trend-test")
+
+        engine_up = MultiTimeframeBacktestEngine(config=config)
+        result_up = await engine_up.run(strategy, data_up)
+
+        strategy2 = GridAdapter(name="grid-trend-test")
+        engine_down = MultiTimeframeBacktestEngine(config=config)
+        result_down = await engine_down.run(strategy2, data_down)
+
+        # Both should complete
+        assert len(result_up.equity_curve) > 0
+        assert len(result_down.equity_curve) > 0
+
+    async def test_all_strategies_same_data(self, config, data_7days):
+        """All four strategy types should run on the same data without errors."""
+        from bot.strategies.trend_follower_adapter import TrendFollowerAdapter
+
+        config.warmup_bars = 60
+        strategies = [
+            GridAdapter(name="grid-all"),
+            DCAAdapter(name="dca-all"),
+            TrendFollowerAdapter(
+                initial_capital=Decimal("10000"),
+                name="tf-all",
+                log_trades=False,
+            ),
+        ]
+
+        # Load longer data for TF warmup
+        loader = MultiTimeframeDataLoader()
+        data = loader.load(
+            "BTC/USDT", datetime(2024, 1, 1), datetime(2024, 1, 15), trend="up"
+        )
+
+        for strategy in strategies:
+            engine = MultiTimeframeBacktestEngine(config=config)
+            result = await engine.run(strategy, data)
+            assert isinstance(result, BacktestResult)
+            assert len(result.equity_curve) > 0


### PR DESCRIPTION
## Summary
- **GridAdapter**: Wraps `GridEngine` to conform to `BaseStrategy` interface for backtesting grid trading strategies with configurable levels, profit targets, and grid ranges
- **DCAAdapter**: Implements DCA (Dollar Cost Averaging) strategy with safety order averaging as `BaseStrategy`, supporting configurable order sizes, deviation thresholds, and take profit targets
- **StrategyComparison**: Utility to run multiple strategies on the same market data and produce comparative rankings (return%, win rate, trades, drawdown, Sharpe) and formatted ASCII reports
- **31 tests** covering unit tests for both adapters, integration tests through `MultiTimeframeBacktestEngine`, and cross-strategy comparison scenarios

## Test plan
- [x] GridAdapter unit tests (9 tests): name/type, analyze, signals, positions, TP/SL, reset, performance
- [x] DCAAdapter unit tests (8 tests): name/type, analyze, signals, safety orders, reset, performance
- [x] Grid backtest integration (2 tests): engine run + balance verification
- [x] DCA backtest integration (2 tests): engine run + balance verification
- [x] SMC backtest integration (1 test): with patched SMCConfig
- [x] TrendFollower backtest integration (1 test): single-timeframe strategy
- [x] StrategyComparison tests (6 tests): rankings, summary, winner, report format, generated data
- [x] Multi-trend comparison tests (2 tests): uptrend vs downtrend, all strategies on same data

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)