### PR TITLE
feat: Gradual capital deployment and v2.0 documentation (#181, #182)

### DIFF
--- a/bot/utils/capital_manager.py
+++ b/bot/utils/capital_manager.py
@@ -1,0 +1,322 @@
+"""
+Gradual capital deployment manager for TRADERAGENT.
+
+Implements the phased capital scaling strategy:
+- Phase 1: 5% capital allocation (3 days monitoring)
+- Phase 2: 25% allocation (1 week monitoring)
+- Phase 3: 100% allocation (production)
+
+Each phase has performance gates that must be met before scaling up.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
+from bot.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class DeploymentPhase(str, Enum):
+    """Capital deployment phases."""
+    PHASE_1 = "phase_1_5pct"
+    PHASE_2 = "phase_2_25pct"
+    PHASE_3 = "phase_3_100pct"
+    HALTED = "halted"
+
+
+@dataclass
+class PhaseConfig:
+    """Configuration for a deployment phase."""
+    phase: DeploymentPhase
+    allocation_pct: Decimal
+    min_duration_days: int
+    max_drawdown_pct: Decimal
+    min_trades: int
+    min_win_rate: Decimal
+
+
+@dataclass
+class PhaseMetrics:
+    """Recorded metrics for a deployment phase."""
+    phase: DeploymentPhase
+    started_at: datetime
+    total_trades: int = 0
+    winning_trades: int = 0
+    total_pnl: Decimal = Decimal("0")
+    max_drawdown_pct: Decimal = Decimal("0")
+    peak_balance: Decimal = Decimal("0")
+    current_balance: Decimal = Decimal("0")
+    errors_count: int = 0
+
+    @property
+    def win_rate(self) -> Decimal:
+        if self.total_trades == 0:
+            return Decimal("0")
+        return Decimal(str(self.winning_trades)) / Decimal(str(self.total_trades))
+
+    @property
+    def duration_days(self) -> int:
+        delta = datetime.now(timezone.utc) - self.started_at
+        return delta.days
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "phase": self.phase.value,
+            "started_at": self.started_at.isoformat(),
+            "duration_days": self.duration_days,
+            "total_trades": self.total_trades,
+            "winning_trades": self.winning_trades,
+            "win_rate": float(self.win_rate),
+            "total_pnl": str(self.total_pnl),
+            "max_drawdown_pct": str(self.max_drawdown_pct),
+            "current_balance": str(self.current_balance),
+            "errors_count": self.errors_count,
+        }
+
+
+@dataclass
+class ScalingDecision:
+    """Decision on whether to scale up."""
+    can_scale: bool
+    current_phase: DeploymentPhase
+    next_phase: DeploymentPhase | None
+    reasons: list[str] = field(default_factory=list)
+    blockers: list[str] = field(default_factory=list)
+
+
+# Default phase configurations
+DEFAULT_PHASES = [
+    PhaseConfig(
+        phase=DeploymentPhase.PHASE_1,
+        allocation_pct=Decimal("0.05"),
+        min_duration_days=3,
+        max_drawdown_pct=Decimal("0.05"),
+        min_trades=5,
+        min_win_rate=Decimal("0.40"),
+    ),
+    PhaseConfig(
+        phase=DeploymentPhase.PHASE_2,
+        allocation_pct=Decimal("0.25"),
+        min_duration_days=7,
+        max_drawdown_pct=Decimal("0.10"),
+        min_trades=20,
+        min_win_rate=Decimal("0.45"),
+    ),
+    PhaseConfig(
+        phase=DeploymentPhase.PHASE_3,
+        allocation_pct=Decimal("1.00"),
+        min_duration_days=0,  # No minimum for full deployment
+        max_drawdown_pct=Decimal("0.15"),
+        min_trades=0,
+        min_win_rate=Decimal("0"),
+    ),
+]
+
+
+class CapitalManager:
+    """
+    Manages gradual capital deployment with performance gates.
+
+    Usage:
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        # ... trading happens ...
+        cm.record_trade(won=True, pnl=Decimal("50"))
+        decision = cm.evaluate_scaling()
+        if decision.can_scale:
+            cm.advance_phase()
+    """
+
+    def __init__(
+        self,
+        total_capital: Decimal = Decimal("10000"),
+        phases: list[PhaseConfig] | None = None,
+    ):
+        self.total_capital = total_capital
+        self.phases = phases or DEFAULT_PHASES
+        self.current_phase: DeploymentPhase = DeploymentPhase.HALTED
+        self.current_metrics: PhaseMetrics | None = None
+        self.phase_history: list[PhaseMetrics] = []
+
+    @property
+    def allocated_capital(self) -> Decimal:
+        """Capital allocated for current phase."""
+        if self.current_phase == DeploymentPhase.HALTED:
+            return Decimal("0")
+        config = self._get_phase_config(self.current_phase)
+        return self.total_capital * config.allocation_pct
+
+    def _get_phase_config(self, phase: DeploymentPhase) -> PhaseConfig:
+        for p in self.phases:
+            if p.phase == phase:
+                return p
+        raise ValueError(f"Unknown phase: {phase}")
+
+    def start_phase_1(self) -> Decimal:
+        """Start Phase 1: 5% capital allocation."""
+        self.current_phase = DeploymentPhase.PHASE_1
+        self.current_metrics = PhaseMetrics(
+            phase=DeploymentPhase.PHASE_1,
+            started_at=datetime.now(timezone.utc),
+            current_balance=self.allocated_capital,
+            peak_balance=self.allocated_capital,
+        )
+        logger.info(
+            "capital_phase_started",
+            phase="phase_1",
+            allocation=str(self.allocated_capital),
+        )
+        return self.allocated_capital
+
+    def record_trade(self, won: bool, pnl: Decimal) -> None:
+        """Record a trade result."""
+        if not self.current_metrics:
+            raise RuntimeError("No active phase")
+
+        self.current_metrics.total_trades += 1
+        if won:
+            self.current_metrics.winning_trades += 1
+        self.current_metrics.total_pnl += pnl
+        self.current_metrics.current_balance += pnl
+
+        if self.current_metrics.current_balance > self.current_metrics.peak_balance:
+            self.current_metrics.peak_balance = self.current_metrics.current_balance
+
+        # Update drawdown
+        if self.current_metrics.peak_balance > 0:
+            drawdown = (
+                self.current_metrics.peak_balance - self.current_metrics.current_balance
+            ) / self.current_metrics.peak_balance
+            if drawdown > self.current_metrics.max_drawdown_pct:
+                self.current_metrics.max_drawdown_pct = drawdown
+
+    def record_error(self) -> None:
+        """Record an error event."""
+        if self.current_metrics:
+            self.current_metrics.errors_count += 1
+
+    def evaluate_scaling(self) -> ScalingDecision:
+        """Evaluate whether performance gates are met for scaling up."""
+        if not self.current_metrics:
+            return ScalingDecision(
+                can_scale=False,
+                current_phase=self.current_phase,
+                next_phase=None,
+                blockers=["No active phase"],
+            )
+
+        config = self._get_phase_config(self.current_phase)
+        metrics = self.current_metrics
+
+        # Determine next phase
+        phase_order = [DeploymentPhase.PHASE_1, DeploymentPhase.PHASE_2, DeploymentPhase.PHASE_3]
+        current_idx = phase_order.index(self.current_phase)
+        if current_idx >= len(phase_order) - 1:
+            return ScalingDecision(
+                can_scale=False,
+                current_phase=self.current_phase,
+                next_phase=None,
+                reasons=["Already at maximum allocation"],
+            )
+        next_phase = phase_order[current_idx + 1]
+
+        # Check gates
+        blockers = []
+        reasons = []
+
+        # Duration check
+        if metrics.duration_days < config.min_duration_days:
+            blockers.append(
+                f"Duration {metrics.duration_days}d < required {config.min_duration_days}d"
+            )
+        else:
+            reasons.append(f"Duration gate passed ({metrics.duration_days}d)")
+
+        # Min trades check
+        if metrics.total_trades < config.min_trades:
+            blockers.append(
+                f"Trades {metrics.total_trades} < required {config.min_trades}"
+            )
+        else:
+            reasons.append(f"Trade count gate passed ({metrics.total_trades})")
+
+        # Win rate check
+        if metrics.total_trades > 0 and metrics.win_rate < config.min_win_rate:
+            blockers.append(
+                f"Win rate {metrics.win_rate:.2%} < required {config.min_win_rate:.2%}"
+            )
+        elif metrics.total_trades > 0:
+            reasons.append(f"Win rate gate passed ({metrics.win_rate:.2%})")
+
+        # Drawdown check
+        if metrics.max_drawdown_pct > config.max_drawdown_pct:
+            blockers.append(
+                f"Drawdown {metrics.max_drawdown_pct:.2%} > max {config.max_drawdown_pct:.2%}"
+            )
+        else:
+            reasons.append(f"Drawdown gate passed ({metrics.max_drawdown_pct:.2%})")
+
+        # PnL check (must be positive)
+        if metrics.total_pnl < 0:
+            blockers.append(f"Net PnL is negative ({metrics.total_pnl})")
+        else:
+            reasons.append(f"PnL positive ({metrics.total_pnl})")
+
+        can_scale = len(blockers) == 0
+
+        return ScalingDecision(
+            can_scale=can_scale,
+            current_phase=self.current_phase,
+            next_phase=next_phase,
+            reasons=reasons,
+            blockers=blockers,
+        )
+
+    def advance_phase(self) -> Decimal:
+        """Advance to the next deployment phase."""
+        decision = self.evaluate_scaling()
+        if not decision.can_scale:
+            raise RuntimeError(
+                f"Cannot advance: {', '.join(decision.blockers)}"
+            )
+
+        # Archive current metrics
+        if self.current_metrics:
+            self.phase_history.append(self.current_metrics)
+
+        self.current_phase = decision.next_phase
+        self.current_metrics = PhaseMetrics(
+            phase=self.current_phase,
+            started_at=datetime.now(timezone.utc),
+            current_balance=self.allocated_capital,
+            peak_balance=self.allocated_capital,
+        )
+
+        logger.info(
+            "capital_phase_advanced",
+            phase=self.current_phase.value,
+            allocation=str(self.allocated_capital),
+        )
+        return self.allocated_capital
+
+    def halt(self, reason: str = "manual") -> None:
+        """Halt deployment — stop all trading."""
+        if self.current_metrics:
+            self.phase_history.append(self.current_metrics)
+        self.current_phase = DeploymentPhase.HALTED
+        self.current_metrics = None
+        logger.warning("capital_deployment_halted", reason=reason)
+
+    def get_report(self) -> dict[str, Any]:
+        """Get comprehensive deployment report."""
+        return {
+            "total_capital": str(self.total_capital),
+            "current_phase": self.current_phase.value,
+            "allocated_capital": str(self.allocated_capital),
+            "current_metrics": self.current_metrics.to_dict() if self.current_metrics else None,
+            "phase_history": [m.to_dict() for m in self.phase_history],
+        }

--- a/docs/v2/API_DOCS.md
+++ b/docs/v2/API_DOCS.md
@@ -1,0 +1,292 @@
+# TRADERAGENT v2.0 API Documentation
+
+## Exchange Client
+
+### ByBitDirectClient
+
+**Module**: `bot/api/bybit_direct_client.py`
+
+Direct implementation of ByBit V5 API with demo trading support.
+
+```python
+from bot.api.bybit_direct_client import ByBitDirectClient
+
+client = ByBitDirectClient(
+    api_key="your_key",
+    api_secret="your_secret",
+    testnet=True,          # Use demo trading endpoint
+    market_type="linear",  # "linear" (USDT perps) or "spot"
+)
+await client.initialize()
+```
+
+#### Methods
+
+| Method | Description | Returns |
+|--------|-------------|---------|
+| `initialize()` | Create HTTP session and load markets | `None` |
+| `close()` | Close HTTP session | `None` |
+| `fetch_ticker(symbol)` | Get current price data | `dict` |
+| `fetch_markets()` | Get all available markets | `dict` |
+| `fetch_balance()` | Get account balance | `dict` |
+| `fetch_open_orders(symbol)` | Get open orders | `list` |
+| `create_limit_order(symbol, side, amount, price)` | Place limit order | `dict` |
+| `create_market_order(symbol, side, amount)` | Place market order | `dict` |
+| `cancel_order(order_id, symbol)` | Cancel an order | `dict` |
+| `fetch_klines(symbol, interval, limit)` | Get candlestick data | `list` |
+| `get_statistics()` | Get client statistics | `dict` |
+
+#### URLs
+
+| Environment | URL |
+|------------|-----|
+| Production | `https://api.bybit.com` |
+| Demo Trading | `https://api-demo.bybit.com` |
+
+#### Authentication
+
+All private endpoints use HMAC SHA256 signatures:
+- Timestamp + API key + recv_window + query string/body
+- `recv_window` = 10000ms (handles server time drift)
+
+#### Error Handling
+
+```python
+from bot.api.exceptions import (
+    AuthenticationError,    # Invalid API key/secret
+    RateLimitError,         # Too many requests
+    InsufficientFundsError, # Not enough balance
+    InvalidOrderError,      # Bad order params
+    NetworkError,           # Connection issues
+    ExchangeAPIError,       # Generic API error
+)
+```
+
+Automatic retry (via tenacity) on `NetworkError` and `RateLimitError` with exponential backoff.
+
+---
+
+## Strategy Interface
+
+### BaseStrategy (Abstract)
+
+**Module**: `bot/strategies/base.py`
+
+```python
+from bot.strategies.base import BaseStrategy
+
+class MyStrategy(BaseStrategy):
+    @property
+    def strategy_type(self) -> str:
+        return "my_strategy"
+
+    def analyze_market(self, *dataframes: pd.DataFrame) -> BaseMarketAnalysis:
+        ...
+
+    def generate_signal(self, df: pd.DataFrame, balance: Decimal) -> BaseSignal | None:
+        ...
+
+    def open_position(self) -> PositionInfo:
+        ...
+
+    def update_positions(self, current_price: Decimal, df: pd.DataFrame) -> list[PositionInfo]:
+        ...
+
+    def close_position(self) -> PositionInfo:
+        ...
+
+    def get_performance(self) -> StrategyPerformance:
+        ...
+```
+
+### Strategy Adapters
+
+| Adapter | Module | Strategy Type |
+|---------|--------|--------------|
+| `SMCStrategyAdapter` | `bot/strategies/smc_adapter.py` | `"smc"` |
+| `TrendFollowerAdapter` | `bot/strategies/trend_follower_adapter.py` | `"trend_follower"` |
+| `GridAdapter` | `bot/strategies/grid_adapter.py` | `"grid"` |
+| `DCAAdapter` | `bot/strategies/dca_adapter.py` | `"dca"` |
+
+---
+
+## Orchestrator
+
+### BotOrchestrator
+
+**Module**: `bot/orchestrator/bot_orchestrator.py`
+
+Manages the trading loop: strategy execution, order placement, and position tracking.
+
+```python
+from bot.orchestrator.bot_orchestrator import BotOrchestrator, BotState
+
+orchestrator = BotOrchestrator(
+    name="btc_smc",
+    strategy=smc_adapter,
+    client=bybit_client,
+    db_manager=db_manager,
+)
+```
+
+#### States
+
+| State | Description |
+|-------|-------------|
+| `INITIALIZING` | Setting up components |
+| `RUNNING` | Actively trading |
+| `PAUSED` | No new trades, positions maintained |
+| `STOPPED` | Fully stopped |
+| `ERROR` | Error state, needs intervention |
+
+---
+
+## Database
+
+### DatabaseManager
+
+**Module**: `bot/database/manager.py`
+
+Async database operations for credentials, bots, orders, trades, and grid levels.
+
+```python
+from bot.database.manager import DatabaseManager
+
+db = DatabaseManager(database_url="sqlite+aiosqlite:///trading.db")
+await db.initialize()
+```
+
+#### Models
+
+| Model | Table | Purpose |
+|-------|-------|---------|
+| `Credential` | `credentials` | API key storage |
+| `BotModel` | `bots` | Bot configuration |
+| `Order` | `orders` | Order history |
+| `Trade` | `trades` | Trade records |
+| `GridLevel` | `grid_levels` | Grid strategy levels |
+| `BotLog` | `bot_logs` | Structured logs |
+
+---
+
+## Capital Manager
+
+### CapitalManager
+
+**Module**: `bot/utils/capital_manager.py`
+
+Phased capital deployment with performance gates.
+
+```python
+from bot.utils.capital_manager import CapitalManager
+
+cm = CapitalManager(total_capital=Decimal("10000"))
+```
+
+#### Methods
+
+| Method | Description | Returns |
+|--------|-------------|---------|
+| `start_phase_1()` | Begin with 5% allocation | `Decimal` (allocated capital) |
+| `record_trade(won, pnl)` | Record a trade result | `None` |
+| `record_error()` | Record an error event | `None` |
+| `evaluate_scaling()` | Check if scaling gates are met | `ScalingDecision` |
+| `advance_phase()` | Scale to next phase | `Decimal` (new allocation) |
+| `halt(reason)` | Stop all trading | `None` |
+| `get_report()` | Get deployment status report | `dict` |
+
+#### ScalingDecision
+
+```python
+@dataclass
+class ScalingDecision:
+    can_scale: bool
+    current_phase: DeploymentPhase
+    next_phase: DeploymentPhase | None
+    reasons: list[str]    # Passed gates
+    blockers: list[str]   # Failed gates
+```
+
+---
+
+## Security Audit
+
+### SecurityAuditor
+
+**Module**: `bot/utils/security_audit.py`
+
+```python
+from bot.utils.security_audit import SecurityAuditor
+
+auditor = SecurityAuditor(project_root="/path/to/project")
+report = auditor.run_full_audit()
+```
+
+#### Checks
+
+| Check | Severity | Description |
+|-------|----------|-------------|
+| `env_file_protected` | critical | `.env` in `.gitignore` |
+| `no_hardcoded_secrets` | critical | No API keys in source |
+| `gitignore_complete` | warning | Essential patterns present |
+| `debug_disabled` | warning | DEBUG mode off |
+| `env_vars_set` | warning | Required vars present |
+| `database_url_secure` | warning | SSL for remote DB |
+| `redis_url_secure` | info | Redis connection check |
+
+---
+
+## Config Validator
+
+### ConfigValidator
+
+**Module**: `bot/utils/config_validator.py`
+
+```python
+from bot.utils.config_validator import ConfigValidator
+
+validator = ConfigValidator()
+report = validator.run_full_validation(
+    risk={"risk_per_trade": Decimal("0.02")},
+    grid={"num_levels": 10},
+    dca={"max_safety_orders": 5},
+)
+```
+
+#### Validation Categories
+
+| Category | Checks |
+|----------|--------|
+| `risk` | risk_per_trade, max_exposure, max_daily_loss, min_risk_reward |
+| `strategy` | grid_levels, grid_total_investment, grid_range, dca_safety_orders, dca_max_capital, dca_take_profit |
+
+---
+
+## Event System
+
+### TradingEvent
+
+**Module**: `bot/orchestrator/events.py`
+
+```python
+from bot.orchestrator.events import EventType, TradingEvent
+
+event = TradingEvent(
+    event_type=EventType.TRADE_OPENED,
+    bot_name="btc_smc",
+    data={"symbol": "BTC/USDT", "side": "buy", "amount": "0.001"},
+)
+```
+
+#### Event Types
+
+| Type | Description |
+|------|-------------|
+| `TRADE_OPENED` | New position opened |
+| `TRADE_CLOSED` | Position closed |
+| `ORDER_PLACED` | Order submitted |
+| `ORDER_FILLED` | Order executed |
+| `ORDER_CANCELLED` | Order cancelled |
+| `SIGNAL_GENERATED` | New signal detected |
+| `ERROR` | Error occurred |
+| `STATUS_CHANGE` | Bot state changed |

--- a/docs/v2/STRATEGY_DOCS.md
+++ b/docs/v2/STRATEGY_DOCS.md
@@ -1,0 +1,190 @@
+# TRADERAGENT v2.0 Strategy Documentation
+
+## Architecture
+
+All strategies implement the `BaseStrategy` abstract class (`bot/strategies/base.py`), providing a unified interface for the `BotOrchestrator`.
+
+### Strategy Lifecycle
+
+```
+analyze_market(dfs...) -> BaseMarketAnalysis
+        |
+generate_signal(df, balance) -> BaseSignal | None
+        |
+open_position() -> PositionInfo
+        |
+update_positions(price, df) -> list[PositionInfo]  (check exits)
+        |
+close_position() -> PositionInfo
+```
+
+### Unified Types
+
+| Type | Purpose |
+|------|---------|
+| `SignalDirection` | `LONG` or `SHORT` |
+| `BaseSignal` | Entry price, SL, TP, confidence, R:R |
+| `BaseMarketAnalysis` | Trend, sentiment, support/resistance |
+| `PositionInfo` | Open position with entry, size, PnL |
+| `StrategyPerformance` | Win rate, PnL, Sharpe, drawdown |
+| `ExitReason` | TP, SL, trailing stop, breakeven, etc. |
+
+---
+
+## 1. SMC Strategy (Smart Money Concepts)
+
+**Adapter**: `bot/strategies/smc_adapter.py` -> `SMCStrategyAdapter`
+**Core**: `bot/strategies/smc/smc_strategy.py` -> `SMCStrategy`
+**Config**: `bot/strategies/smc/config.py` -> `SMCConfig`
+
+### Overview
+
+Institutional-grade strategy based on Smart Money Concepts. Analyzes market structure across 4 timeframes to identify high-probability entries at Order Blocks and Fair Value Gaps.
+
+### Multi-Timeframe Analysis
+
+| Timeframe | Purpose |
+|-----------|---------|
+| D1 | Global trend direction |
+| H4 | Market structure (BOS, CHoCH) |
+| H1 | Confluence zones (OB, FVG) |
+| M15 | Entry signals and timing |
+
+### Components
+
+1. **Market Structure Analyzer** - Identifies swing highs/lows, Break of Structure (BOS), Change of Character (CHoCH)
+2. **Confluence Zone Analyzer** - Detects Order Blocks and Fair Value Gaps
+3. **Entry Signal Generator** - Finds price action patterns at confluence zones
+4. **Position Manager** - Kelly Criterion sizing, dynamic SL/TP, trailing stops
+
+### Key Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `trend_timeframe` | `"1d"` | Timeframe for global trend |
+| `structure_timeframe` | `"4h"` | Timeframe for market structure |
+| `working_timeframe` | `"1h"` | Timeframe for confluence zones |
+| `entry_timeframe` | `"15m"` | Timeframe for entries |
+| `swing_length` | `5` | Candles for swing identification |
+| `trend_period` | `20` | Trend detection lookback |
+| `order_block_lookback` | `50` | OB search depth |
+| `fvg_min_size` | `0.001` | Min FVG size (% of price) |
+| `risk_per_trade` | `0.02` | 2% risk per trade |
+| `min_risk_reward` | `2.5` | Minimum R:R ratio |
+| `max_position_size` | `10000` | Max USD per position |
+| `use_trailing_stop` | `true` | Enable trailing stop |
+| `trailing_stop_activation` | `0.015` | Activate at 1.5% profit |
+| `trailing_stop_distance` | `0.005` | Trail by 0.5% |
+| `require_volume_confirmation` | `true` | Volume filter |
+| `min_volume_multiplier` | `1.5` | 1.5x avg volume required |
+
+---
+
+## 2. Trend-Follower Strategy
+
+**Adapter**: `bot/strategies/trend_follower_adapter.py` -> `TrendFollowerAdapter`
+**Core**: `bot/strategies/trend_follower/` module
+
+### Overview
+
+Follows established trends using technical indicators. Uses a single timeframe and identifies trend direction via moving averages, RSI, and momentum indicators.
+
+### Analysis Flow
+
+1. Calculate moving averages (fast/slow)
+2. Determine trend direction via crossovers
+3. Confirm with RSI and momentum
+4. Generate entry on pullback to support/resistance
+5. Trail stops with ATR-based distance
+
+### Key Characteristics
+
+- Single-timeframe operation (uses first DataFrame only)
+- Lower trade frequency, higher holding period
+- Trend confirmation via multiple indicators
+- ATR-based stop loss placement
+
+---
+
+## 3. Grid Strategy
+
+**Adapter**: `bot/strategies/grid_adapter.py` -> `GridAdapter`
+**Core**: `bot/strategies/grid/` module
+
+### Overview
+
+Places a grid of buy and sell orders at fixed price intervals around a center price. Profits from price oscillation within a range.
+
+### How It Works
+
+1. Define price range (upper/lower bounds)
+2. Place grid levels evenly across the range
+3. Buy when price hits a lower grid level
+4. Sell when price hits an upper grid level
+5. Profit from the spread between levels
+
+### Key Parameters
+
+| Parameter | Limit | Description |
+|-----------|-------|-------------|
+| `num_levels` | Max 50 | Number of grid levels |
+| `amount_per_grid` | - | USD per grid order |
+| `grid_range_pct` | Max 20% | Price range as % of center |
+
+### Risk Considerations
+
+- Total investment = `num_levels * amount_per_grid` (max $50,000)
+- Works best in ranging/sideways markets
+- Can accumulate losses in strong trends
+
+---
+
+## 4. DCA Strategy (Dollar Cost Averaging)
+
+**Adapter**: `bot/strategies/dca_adapter.py` -> `DCAAdapter`
+**Core**: `bot/strategies/dca/` module
+
+### Overview
+
+Places an initial order and adds safety orders as price dips, averaging down the entry price. Takes profit when the averaged price reaches the take-profit target.
+
+### How It Works
+
+1. Place base order at current price
+2. If price drops, place safety orders at defined intervals
+3. Each safety order averages down the entry
+4. Take profit when average price + TP% reached
+
+### Key Parameters
+
+| Parameter | Limit | Description |
+|-----------|-------|-------------|
+| `base_order_size` | - | Initial order size in USD |
+| `safety_order_size` | - | Safety order size in USD |
+| `max_safety_orders` | Max 10 | Maximum safety orders |
+| `take_profit_pct` | Min 0.5% | Take profit percentage |
+
+### Risk Considerations
+
+- Max capital = `base + (safety_size * max_orders)` (max $50,000)
+- Can tie up significant capital in drawdowns
+- Works best in volatile markets with mean reversion
+
+---
+
+## Strategy Selection Guide
+
+| Market Condition | Recommended Strategy |
+|-----------------|---------------------|
+| Strong trend | SMC or Trend-Follower |
+| Range-bound | Grid |
+| High volatility + mean reversion | DCA |
+| Uncertain | SMC (multi-timeframe analysis) |
+
+## Switching Strategies
+
+Use the Telegram `/switch_strategy` command or the orchestrator API:
+
+```python
+orchestrator.switch_strategy("smc")  # or "trend_follower", "grid", "dca"
+```

--- a/docs/v2/TELEGRAM_REFERENCE.md
+++ b/docs/v2/TELEGRAM_REFERENCE.md
@@ -1,0 +1,181 @@
+# TRADERAGENT v2.0 Telegram Command Reference
+
+## Setup
+
+### Prerequisites
+
+1. Create a Telegram bot via [@BotFather](https://t.me/BotFather)
+2. Get your chat ID via [@userinfobot](https://t.me/userinfobot)
+3. Set environment variables:
+
+```env
+TELEGRAM_BOT_TOKEN=123456789:ABCdefGHIjklMNOpqrsTUVwxyz
+TELEGRAM_CHAT_ID=your_chat_id
+REDIS_URL=redis://localhost:6379
+```
+
+### Security
+
+Only chat IDs in the `allowed_chat_ids` list can execute commands. Unauthorized users receive no response.
+
+---
+
+## Control Commands
+
+### `/start`
+
+Displays welcome message and available commands.
+
+### `/help`
+
+Shows the full command list with descriptions.
+
+### `/start_bot [name]`
+
+Starts a specific trading bot by name.
+
+**Example**: `/start_bot btc_smc`
+
+### `/stop_bot [name]`
+
+Stops a specific trading bot. Cancels open orders and closes positions.
+
+**Example**: `/stop_bot btc_smc`
+
+### `/pause`
+
+Pauses all active trading bots. Existing positions are maintained but no new trades are opened.
+
+### `/resume`
+
+Resumes paused trading bots.
+
+---
+
+## Monitoring Commands
+
+### `/status`
+
+Shows the current state of all bots:
+
+```
+Bot: btc_smc
+  State: RUNNING
+  Strategy: smc
+  Uptime: 2d 5h 30m
+
+Bot: eth_grid
+  State: PAUSED
+  Strategy: grid
+```
+
+### `/balance`
+
+Fetches and displays current account balance from ByBit.
+
+```
+Balance:
+  Total: $10,234.56
+  Free: $8,100.00
+  Used: $2,134.56
+```
+
+### `/orders`
+
+Lists open orders across all bots.
+
+```
+Open Orders:
+  BTC/USDT BUY LIMIT @ $42,000 (0.01 BTC)
+  ETH/USDT SELL LIMIT @ $3,200 (0.5 ETH)
+```
+
+### `/positions`
+
+Shows current open positions with unrealized PnL.
+
+```
+Positions:
+  BTC/USDT LONG 0.01 BTC
+    Entry: $43,000 | Current: $43,500
+    PnL: +$5.00 (+1.16%)
+```
+
+### `/pnl`
+
+Shows profit/loss summary.
+
+```
+PnL Summary:
+  Today: +$125.50
+  This Week: +$430.00
+  Total: +$1,245.00
+```
+
+### `/list`
+
+Lists all configured bots and their states.
+
+```
+Configured Bots:
+  1. btc_smc [RUNNING] - SMC on BTC/USDT
+  2. eth_grid [STOPPED] - Grid on ETH/USDT
+  3. sol_dca [PAUSED] - DCA on SOL/USDT
+```
+
+### `/report`
+
+Generates a detailed performance report including:
+- Win rate, total trades, profit factor
+- Max drawdown, Sharpe ratio
+- Per-strategy breakdown
+- Capital deployment phase status
+
+---
+
+## Strategy Commands
+
+### `/switch_strategy [bot_name] [strategy]`
+
+Switches a bot's active strategy.
+
+**Strategies**: `smc`, `trend_follower`, `grid`, `dca`
+
+**Example**: `/switch_strategy btc_smc trend_follower`
+
+---
+
+## Event Notifications
+
+When Redis is configured, the bot automatically sends notifications for:
+
+| Event | Description |
+|-------|-------------|
+| `TRADE_OPENED` | New position opened |
+| `TRADE_CLOSED` | Position closed with PnL |
+| `ORDER_FILLED` | Limit order executed |
+| `SIGNAL_GENERATED` | New trading signal detected |
+| `ERROR` | Strategy or API error |
+| `PHASE_ADVANCED` | Capital deployment phase changed |
+
+Notifications are pushed to all `allowed_chat_ids` via Redis Pub/Sub.
+
+---
+
+## Multi-Bot Management
+
+The Telegram bot manages multiple `BotOrchestrator` instances. Each bot has:
+- A unique name (e.g., `btc_smc`, `eth_grid`)
+- Its own strategy configuration
+- Independent state (RUNNING, PAUSED, STOPPED)
+
+```python
+TelegramBot(
+    token="...",
+    allowed_chat_ids=[123456789],
+    orchestrators={
+        "btc_smc": orchestrator_1,
+        "eth_grid": orchestrator_2,
+    },
+)
+```

--- a/docs/v2/TROUBLESHOOTING.md
+++ b/docs/v2/TROUBLESHOOTING.md
@@ -1,0 +1,207 @@
+# TRADERAGENT v2.0 Troubleshooting Guide
+
+## Connection Issues
+
+### ByBit API Authentication Failed
+
+**Symptom**: `AuthenticationError: Invalid API key`
+
+**Solutions**:
+1. Verify API key/secret are correct in `.env`
+2. For testnet: use `testnet=True` in client initialization
+3. For demo trading: the URL is `https://api-demo.bybit.com` (handled automatically)
+4. Check that API key permissions include trading
+5. Ensure system clock is synchronized (API uses timestamp-based signatures with 10s window)
+
+### Rate Limit Exceeded
+
+**Symptom**: `RateLimitError: 429 Too Many Requests`
+
+**Solutions**:
+1. The client has built-in retry with exponential backoff (tenacity)
+2. Reduce polling frequency in strategy config
+3. ByBit rate limits: 120 requests/min for order endpoints, 600/min for market data
+
+### Network Timeout
+
+**Symptom**: `NetworkError: Connection timeout`
+
+**Solutions**:
+1. Check internet connectivity
+2. Verify ByBit API status at https://status.bybit.com
+3. The client retries automatically up to 3 times
+4. Consider increasing timeout in aiohttp session config
+
+---
+
+## Strategy Issues
+
+### SMC Strategy Not Generating Signals
+
+**Possible causes**:
+1. **Insufficient data**: SMC requires 4 timeframes (D1, H4, H1, M15). Ensure all are loaded.
+2. **No confluence zones**: Market may not have active Order Blocks or Fair Value Gaps
+3. **Volume filter**: If `require_volume_confirmation=True`, low volume periods are filtered
+4. **Risk:Reward too high**: Lower `min_risk_reward` from 2.5 to 2.0 if signals are rare
+
+### Grid Strategy Accumulating Losses
+
+**Possible causes**:
+1. **Trending market**: Grid works best in ranges. Consider switching to SMC or Trend-Follower
+2. **Range too narrow**: Increase `grid_range_pct` to capture wider oscillations
+3. **Too many levels**: Reduce `num_levels` to concentrate capital
+
+### DCA Safety Orders Not Triggering
+
+**Possible causes**:
+1. **Price not dropping enough**: Safety orders require specific price deviation thresholds
+2. **Max safety orders reached**: Check `max_safety_orders` limit
+3. **Insufficient balance**: Each safety order needs available capital
+
+---
+
+## Database Issues
+
+### SQLite Lock Errors
+
+**Symptom**: `OperationalError: database is locked`
+
+**Solutions**:
+1. SQLite doesn't support concurrent writes. Switch to PostgreSQL for production:
+   ```env
+   DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/traderagent
+   ```
+2. For development, ensure only one bot process runs at a time
+
+### Migration Errors
+
+**Symptom**: Table schema mismatch after upgrade
+
+**Solutions**:
+1. For development: delete the SQLite file and restart (tables auto-create)
+2. For production: use Alembic migrations:
+   ```bash
+   alembic upgrade head
+   ```
+
+---
+
+## Telegram Bot Issues
+
+### Bot Not Responding
+
+**Possible causes**:
+1. **Invalid token**: Verify `TELEGRAM_BOT_TOKEN` is correct
+2. **Chat not authorized**: Ensure your chat ID is in `allowed_chat_ids`
+3. **Bot not started**: The event loop must be running for the bot to process messages
+4. **Webhook conflict**: If using webhooks elsewhere, clear them: `bot.delete_webhook()`
+
+### No Event Notifications
+
+**Possible causes**:
+1. **Redis not running**: Start Redis: `redis-server`
+2. **Wrong Redis URL**: Verify `REDIS_URL` in `.env`
+3. **Event listener not started**: Ensure `TelegramBot.run()` is called
+
+---
+
+## Capital Deployment Issues
+
+### Cannot Advance Phase
+
+**Symptom**: `RuntimeError: Cannot advance: Duration 2d < required 3d`
+
+The `CapitalManager` enforces performance gates before scaling:
+
+| Gate | Phase 1 | Phase 2 |
+|------|---------|---------|
+| Duration | 3 days | 7 days |
+| Min trades | 5 | 20 |
+| Win rate | 40% | 45% |
+| Max drawdown | 5% | 10% |
+| Net PnL | Positive | Positive |
+
+Check which gates are blocking:
+```python
+decision = cm.evaluate_scaling()
+print(decision.blockers)  # ['Duration 2d < required 3d', ...]
+print(decision.reasons)   # ['Win rate gate passed (60.00%)', ...]
+```
+
+### Deployment Halted
+
+**Symptom**: Phase shows `HALTED`
+
+The system halts when critical errors occur or when manually stopped. To resume:
+1. Investigate the halt reason in logs
+2. Fix underlying issues
+3. Restart from Phase 1: `cm.start_phase_1()`
+
+---
+
+## Testing Issues
+
+### pdbpp/fancycompleter Error
+
+**Symptom**: `TypeError` related to `fancycompleter` or `pdb`
+
+**Solution**: Always run pytest with `-p no:pdb`:
+```bash
+python -m pytest -p no:pdb -v
+```
+
+### Testnet Tests Skipped
+
+**Symptom**: All testnet tests show `SKIPPED`
+
+**Solution**: Set testnet credentials:
+```bash
+export BYBIT_TESTNET_API_KEY=your_key
+export BYBIT_TESTNET_API_SECRET=your_secret
+python -m pytest tests/testnet/test_testnet_validation.py -p no:pdb -v
+```
+
+### Import Errors
+
+**Symptom**: `ModuleNotFoundError: No module named 'bot'`
+
+**Solution**: Run from project root or install in editable mode:
+```bash
+pip install -e .
+```
+
+---
+
+## Production Readiness Checks
+
+Before deploying to production, run the full audit:
+
+```bash
+# Security audit
+python -c "
+from bot.utils.security_audit import SecurityAuditor
+report = SecurityAuditor().run_full_audit()
+print(report.summary())
+for f in report.critical_failures:
+    print(f'CRITICAL: {f.message}')
+"
+
+# Config validation
+python -c "
+from bot.utils.config_validator import ConfigValidator
+report = ConfigValidator().run_full_validation()
+print(report.summary())
+for f in report.failures:
+    print(f'FAIL: {f.message}')
+"
+```
+
+Both should show `overall_status: PASS` before going live.
+
+---
+
+## Getting Help
+
+- GitHub Issues: https://github.com/alekseymavai/TRADERAGENT/issues
+- Check logs: structured logging with `structlog` — search for `error` severity
+- Enable debug mode: `DEBUG=true` in `.env` (disable for production)

--- a/docs/v2/USER_GUIDE.md
+++ b/docs/v2/USER_GUIDE.md
@@ -1,0 +1,167 @@
+# TRADERAGENT v2.0 User Guide
+
+## Overview
+
+TRADERAGENT v2.0 is an autonomous cryptocurrency trading bot that supports multiple strategies on the ByBit exchange. It provides:
+
+- **4 Trading Strategies**: SMC, Trend-Follower, Grid, DCA
+- **Unified Strategy Interface**: All strategies share a common lifecycle
+- **Telegram Control**: Manage bots via Telegram commands
+- **Gradual Capital Deployment**: Phased scaling from 5% to 100%
+- **Production Safety**: Security audits, config validation, risk limits
+
+## Prerequisites
+
+- Python 3.12+
+- ByBit account (testnet or production)
+- PostgreSQL (optional, SQLite for development)
+- Redis (optional, for Telegram event streaming)
+- Telegram Bot Token (optional, for remote control)
+
+## Installation
+
+```bash
+git clone https://github.com/alekseymavai/TRADERAGENT.git
+cd TRADERAGENT
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Configuration
+
+### Environment Variables
+
+Create a `.env` file in the project root:
+
+```env
+# Required - ByBit API
+BYBIT_TESTNET_API_KEY=your_api_key
+BYBIT_TESTNET_API_SECRET=your_api_secret
+
+# Optional - Database (defaults to SQLite)
+DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/traderagent
+
+# Optional - Redis (for Telegram event streaming)
+REDIS_URL=redis://localhost:6379
+
+# Optional - Telegram
+TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
+TELEGRAM_CHAT_ID=your_chat_id
+
+# Production flags
+DEBUG=false
+```
+
+### Strategy Configuration
+
+Each strategy has a configuration dataclass. See [Strategy Documentation](STRATEGY_DOCS.md) for parameter details.
+
+**SMC Strategy** (`bot/strategies/smc/config.py`):
+```python
+SMCConfig(
+    risk_per_trade=Decimal("0.02"),    # 2% risk per trade
+    min_risk_reward=Decimal("2.5"),    # Minimum 2.5:1 R:R
+    max_position_size=Decimal("10000"),# Max $10,000 per position
+    use_trailing_stop=True,
+)
+```
+
+### Config Validation
+
+Before going live, validate your configuration:
+
+```python
+from bot.utils.config_validator import ConfigValidator
+
+validator = ConfigValidator()
+report = validator.run_full_validation(
+    risk={"risk_per_trade": Decimal("0.02"), "max_exposure": Decimal("0.20")},
+    grid={"num_levels": 10, "amount_per_grid": Decimal("100")},
+    dca={"max_safety_orders": 5},
+)
+print(report.summary())
+# {'total_checks': 10, 'passed': 10, 'failed': 0, 'overall_status': 'PASS'}
+```
+
+**Safe Limits Enforced**:
+| Parameter | Max Value |
+|-----------|-----------|
+| Risk per trade | 5% |
+| Total exposure | 50% |
+| Daily loss | 10% |
+| Min risk:reward | 1.5:1 |
+| Grid levels | 50 |
+| Safety orders | 10 |
+| Position size | $50,000 |
+
+## Capital Deployment
+
+TRADERAGENT uses a phased capital deployment model to protect against losses during initial trading.
+
+### Phase 1: Monitoring (5% capital)
+- Duration: 3 days minimum
+- Requirements: 5+ trades, 40%+ win rate, <5% drawdown, positive PnL
+
+### Phase 2: Scaling (25% capital)
+- Duration: 7 days minimum
+- Requirements: 20+ trades, 45%+ win rate, <10% drawdown, positive PnL
+
+### Phase 3: Full Deployment (100% capital)
+- No minimum duration
+- Continuous monitoring with halt capability
+
+```python
+from bot.utils.capital_manager import CapitalManager
+
+cm = CapitalManager(total_capital=Decimal("10000"))
+cm.start_phase_1()  # Returns Decimal("500")
+
+# After trading...
+cm.record_trade(won=True, pnl=Decimal("50"))
+decision = cm.evaluate_scaling()
+if decision.can_scale:
+    cm.advance_phase()  # Returns Decimal("2500")
+```
+
+## Security Audit
+
+Run a security audit before production deployment:
+
+```python
+from bot.utils.security_audit import SecurityAuditor
+
+auditor = SecurityAuditor()
+report = auditor.run_full_audit()
+print(report.summary())
+```
+
+Checks performed:
+- `.env` file protection (in `.gitignore`)
+- No hardcoded secrets in source files
+- Debug mode disabled
+- Required environment variables set
+- Database/Redis URL security (SSL for remote)
+
+## Running Tests
+
+```bash
+# All tests
+python -m pytest -p no:pdb -v
+
+# Unit tests only
+python -m pytest tests/ -p no:pdb -v --ignore=tests/testnet
+
+# Integration tests
+python -m pytest tests/integration/ -p no:pdb -v
+
+# Load/stress tests
+python -m pytest tests/testnet/test_load_stress.py -p no:pdb -v
+
+# Testnet validation (requires API credentials)
+python -m pytest tests/testnet/test_testnet_validation.py -p no:pdb -v
+```
+
+## Troubleshooting
+
+See [Troubleshooting Guide](TROUBLESHOOTING.md) for common issues and solutions.

--- a/tests/test_capital_manager.py
+++ b/tests/test_capital_manager.py
@@ -1,0 +1,538 @@
+"""
+Tests for the gradual capital deployment manager.
+"""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from bot.utils.capital_manager import (
+    CapitalManager,
+    DeploymentPhase,
+    PhaseConfig,
+    PhaseMetrics,
+    ScalingDecision,
+    DEFAULT_PHASES,
+)
+
+
+# ===========================================================================
+# DeploymentPhase enum
+# ===========================================================================
+
+
+class TestDeploymentPhase:
+    def test_phase_values(self):
+        assert DeploymentPhase.PHASE_1.value == "phase_1_5pct"
+        assert DeploymentPhase.PHASE_2.value == "phase_2_25pct"
+        assert DeploymentPhase.PHASE_3.value == "phase_3_100pct"
+        assert DeploymentPhase.HALTED.value == "halted"
+
+    def test_is_string_enum(self):
+        assert isinstance(DeploymentPhase.PHASE_1, str)
+        assert DeploymentPhase.PHASE_1 == "phase_1_5pct"
+
+
+# ===========================================================================
+# PhaseMetrics
+# ===========================================================================
+
+
+class TestPhaseMetrics:
+    def test_win_rate_zero_trades(self):
+        m = PhaseMetrics(phase=DeploymentPhase.PHASE_1, started_at=datetime.now(timezone.utc))
+        assert m.win_rate == Decimal("0")
+
+    def test_win_rate_calculation(self):
+        m = PhaseMetrics(
+            phase=DeploymentPhase.PHASE_1,
+            started_at=datetime.now(timezone.utc),
+            total_trades=10,
+            winning_trades=7,
+        )
+        assert m.win_rate == Decimal("0.7")
+
+    def test_duration_days(self):
+        m = PhaseMetrics(
+            phase=DeploymentPhase.PHASE_1,
+            started_at=datetime.now(timezone.utc) - timedelta(days=5),
+        )
+        assert m.duration_days == 5
+
+    def test_to_dict(self):
+        m = PhaseMetrics(
+            phase=DeploymentPhase.PHASE_1,
+            started_at=datetime.now(timezone.utc),
+            total_trades=3,
+            winning_trades=2,
+            total_pnl=Decimal("100"),
+            current_balance=Decimal("600"),
+        )
+        d = m.to_dict()
+        assert d["phase"] == "phase_1_5pct"
+        assert d["total_trades"] == 3
+        assert d["winning_trades"] == 2
+        assert float(d["win_rate"]) == pytest.approx(2 / 3)
+        assert d["total_pnl"] == "100"
+        assert d["current_balance"] == "600"
+        assert "started_at" in d
+        assert "duration_days" in d
+
+    def test_default_values(self):
+        m = PhaseMetrics(phase=DeploymentPhase.PHASE_1, started_at=datetime.now(timezone.utc))
+        assert m.total_trades == 0
+        assert m.winning_trades == 0
+        assert m.total_pnl == Decimal("0")
+        assert m.max_drawdown_pct == Decimal("0")
+        assert m.errors_count == 0
+
+
+# ===========================================================================
+# CapitalManager — Initialization
+# ===========================================================================
+
+
+class TestCapitalManagerInit:
+    def test_default_capital(self):
+        cm = CapitalManager()
+        assert cm.total_capital == Decimal("10000")
+
+    def test_custom_capital(self):
+        cm = CapitalManager(total_capital=Decimal("50000"))
+        assert cm.total_capital == Decimal("50000")
+
+    def test_starts_halted(self):
+        cm = CapitalManager()
+        assert cm.current_phase == DeploymentPhase.HALTED
+
+    def test_allocated_capital_when_halted(self):
+        cm = CapitalManager()
+        assert cm.allocated_capital == Decimal("0")
+
+    def test_default_phases(self):
+        cm = CapitalManager()
+        assert len(cm.phases) == 3
+
+    def test_custom_phases(self):
+        custom = [DEFAULT_PHASES[0]]
+        cm = CapitalManager(phases=custom)
+        assert len(cm.phases) == 1
+
+
+# ===========================================================================
+# CapitalManager — Phase 1
+# ===========================================================================
+
+
+class TestCapitalManagerPhase1:
+    def test_start_phase_1(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        alloc = cm.start_phase_1()
+        assert alloc == Decimal("500")  # 5% of 10000
+        assert cm.current_phase == DeploymentPhase.PHASE_1
+
+    def test_allocated_capital_phase_1(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        assert cm.allocated_capital == Decimal("500")
+
+    def test_phase_1_metrics_initialized(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        assert cm.current_metrics is not None
+        assert cm.current_metrics.phase == DeploymentPhase.PHASE_1
+        assert cm.current_metrics.current_balance == Decimal("500")
+        assert cm.current_metrics.peak_balance == Decimal("500")
+
+
+# ===========================================================================
+# CapitalManager — Recording Trades
+# ===========================================================================
+
+
+class TestRecordTrade:
+    def test_record_winning_trade(self):
+        cm = CapitalManager()
+        cm.start_phase_1()
+        cm.record_trade(won=True, pnl=Decimal("50"))
+        assert cm.current_metrics.total_trades == 1
+        assert cm.current_metrics.winning_trades == 1
+        assert cm.current_metrics.total_pnl == Decimal("50")
+
+    def test_record_losing_trade(self):
+        cm = CapitalManager()
+        cm.start_phase_1()
+        cm.record_trade(won=False, pnl=Decimal("-30"))
+        assert cm.current_metrics.total_trades == 1
+        assert cm.current_metrics.winning_trades == 0
+        assert cm.current_metrics.total_pnl == Decimal("-30")
+
+    def test_multiple_trades(self):
+        cm = CapitalManager()
+        cm.start_phase_1()
+        cm.record_trade(won=True, pnl=Decimal("50"))
+        cm.record_trade(won=True, pnl=Decimal("30"))
+        cm.record_trade(won=False, pnl=Decimal("-20"))
+        assert cm.current_metrics.total_trades == 3
+        assert cm.current_metrics.winning_trades == 2
+        assert cm.current_metrics.total_pnl == Decimal("60")
+
+    def test_balance_updated(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        cm.record_trade(won=True, pnl=Decimal("50"))
+        assert cm.current_metrics.current_balance == Decimal("550")
+
+    def test_peak_balance_tracked(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        cm.record_trade(won=True, pnl=Decimal("100"))
+        cm.record_trade(won=False, pnl=Decimal("-50"))
+        assert cm.current_metrics.peak_balance == Decimal("600")
+        assert cm.current_metrics.current_balance == Decimal("550")
+
+    def test_drawdown_tracked(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        # Balance starts at 500, goes to 600, drops to 540
+        cm.record_trade(won=True, pnl=Decimal("100"))
+        cm.record_trade(won=False, pnl=Decimal("-60"))
+        # Drawdown = (600 - 540) / 600 = 10%
+        assert cm.current_metrics.max_drawdown_pct == Decimal("60") / Decimal("600")
+
+    def test_no_active_phase_raises(self):
+        cm = CapitalManager()
+        with pytest.raises(RuntimeError, match="No active phase"):
+            cm.record_trade(won=True, pnl=Decimal("10"))
+
+
+# ===========================================================================
+# CapitalManager — Record Error
+# ===========================================================================
+
+
+class TestRecordError:
+    def test_record_error(self):
+        cm = CapitalManager()
+        cm.start_phase_1()
+        cm.record_error()
+        assert cm.current_metrics.errors_count == 1
+
+    def test_record_error_no_phase(self):
+        cm = CapitalManager()
+        # Should not raise, just no-op
+        cm.record_error()
+
+
+# ===========================================================================
+# CapitalManager — Evaluate Scaling
+# ===========================================================================
+
+
+class TestEvaluateScaling:
+    def _make_ready_cm(self) -> CapitalManager:
+        """Create a CM that meets all Phase 1 scaling gates."""
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        # Backdate start to meet 3-day requirement
+        cm.current_metrics.started_at = datetime.now(timezone.utc) - timedelta(days=4)
+        # Record 5 winning trades
+        for _ in range(5):
+            cm.record_trade(won=True, pnl=Decimal("10"))
+        return cm
+
+    def test_no_active_phase(self):
+        cm = CapitalManager()
+        decision = cm.evaluate_scaling()
+        assert not decision.can_scale
+        assert "No active phase" in decision.blockers
+
+    def test_can_scale_when_gates_met(self):
+        cm = self._make_ready_cm()
+        decision = cm.evaluate_scaling()
+        assert decision.can_scale
+        assert decision.next_phase == DeploymentPhase.PHASE_2
+        assert len(decision.blockers) == 0
+
+    def test_blocked_by_duration(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        # Only 1 day old
+        cm.current_metrics.started_at = datetime.now(timezone.utc) - timedelta(days=1)
+        for _ in range(5):
+            cm.record_trade(won=True, pnl=Decimal("10"))
+        decision = cm.evaluate_scaling()
+        assert not decision.can_scale
+        assert any("Duration" in b for b in decision.blockers)
+
+    def test_blocked_by_trade_count(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        cm.current_metrics.started_at = datetime.now(timezone.utc) - timedelta(days=4)
+        # Only 2 trades, need 5
+        cm.record_trade(won=True, pnl=Decimal("10"))
+        cm.record_trade(won=True, pnl=Decimal("10"))
+        decision = cm.evaluate_scaling()
+        assert not decision.can_scale
+        assert any("Trades" in b for b in decision.blockers)
+
+    def test_blocked_by_win_rate(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        cm.current_metrics.started_at = datetime.now(timezone.utc) - timedelta(days=4)
+        # 1 win, 5 losses = 16.7% win rate < 40%
+        cm.record_trade(won=True, pnl=Decimal("10"))
+        for _ in range(5):
+            cm.record_trade(won=False, pnl=Decimal("-1"))
+        decision = cm.evaluate_scaling()
+        assert not decision.can_scale
+        assert any("Win rate" in b for b in decision.blockers)
+
+    def test_blocked_by_drawdown(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        cm.current_metrics.started_at = datetime.now(timezone.utc) - timedelta(days=4)
+        # Big gain then big loss to trigger >5% drawdown
+        cm.record_trade(won=True, pnl=Decimal("100"))
+        cm.record_trade(won=True, pnl=Decimal("100"))
+        cm.record_trade(won=True, pnl=Decimal("100"))
+        cm.record_trade(won=True, pnl=Decimal("100"))
+        cm.record_trade(won=False, pnl=Decimal("-200"))
+        # peak=900, current=700, drawdown=22%
+        decision = cm.evaluate_scaling()
+        assert not decision.can_scale
+        assert any("Drawdown" in b for b in decision.blockers)
+
+    def test_blocked_by_negative_pnl(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        cm.current_metrics.started_at = datetime.now(timezone.utc) - timedelta(days=4)
+        # 5 trades but net negative (3 wins, 2 big losses)
+        cm.record_trade(won=True, pnl=Decimal("5"))
+        cm.record_trade(won=True, pnl=Decimal("5"))
+        cm.record_trade(won=True, pnl=Decimal("5"))
+        cm.record_trade(won=False, pnl=Decimal("-10"))
+        cm.record_trade(won=False, pnl=Decimal("-10"))
+        decision = cm.evaluate_scaling()
+        assert not decision.can_scale
+        assert any("PnL" in b for b in decision.blockers)
+
+    def test_already_at_max_phase(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.current_phase = DeploymentPhase.PHASE_3
+        cm.current_metrics = PhaseMetrics(
+            phase=DeploymentPhase.PHASE_3,
+            started_at=datetime.now(timezone.utc),
+        )
+        decision = cm.evaluate_scaling()
+        assert not decision.can_scale
+        assert "Already at maximum allocation" in decision.reasons
+
+    def test_scaling_decision_fields(self):
+        cm = self._make_ready_cm()
+        decision = cm.evaluate_scaling()
+        assert decision.current_phase == DeploymentPhase.PHASE_1
+        assert decision.next_phase == DeploymentPhase.PHASE_2
+        assert len(decision.reasons) > 0
+
+
+# ===========================================================================
+# CapitalManager — Advance Phase
+# ===========================================================================
+
+
+class TestAdvancePhase:
+    def _make_ready_cm(self) -> CapitalManager:
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        cm.current_metrics.started_at = datetime.now(timezone.utc) - timedelta(days=4)
+        for _ in range(5):
+            cm.record_trade(won=True, pnl=Decimal("10"))
+        return cm
+
+    def test_advance_to_phase_2(self):
+        cm = self._make_ready_cm()
+        alloc = cm.advance_phase()
+        assert cm.current_phase == DeploymentPhase.PHASE_2
+        assert alloc == Decimal("2500")  # 25% of 10000
+
+    def test_advance_archives_metrics(self):
+        cm = self._make_ready_cm()
+        cm.advance_phase()
+        assert len(cm.phase_history) == 1
+        assert cm.phase_history[0].phase == DeploymentPhase.PHASE_1
+
+    def test_advance_resets_metrics(self):
+        cm = self._make_ready_cm()
+        cm.advance_phase()
+        assert cm.current_metrics.phase == DeploymentPhase.PHASE_2
+        assert cm.current_metrics.total_trades == 0
+        assert cm.current_metrics.current_balance == Decimal("2500")
+
+    def test_advance_fails_if_not_ready(self):
+        cm = CapitalManager()
+        cm.start_phase_1()
+        with pytest.raises(RuntimeError, match="Cannot advance"):
+            cm.advance_phase()
+
+    def test_full_phase_progression(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        # Phase 1
+        cm.start_phase_1()
+        cm.current_metrics.started_at = datetime.now(timezone.utc) - timedelta(days=4)
+        for _ in range(5):
+            cm.record_trade(won=True, pnl=Decimal("10"))
+        cm.advance_phase()
+        assert cm.current_phase == DeploymentPhase.PHASE_2
+
+        # Phase 2
+        cm.current_metrics.started_at = datetime.now(timezone.utc) - timedelta(days=8)
+        for _ in range(20):
+            cm.record_trade(won=True, pnl=Decimal("20"))
+        cm.advance_phase()
+        assert cm.current_phase == DeploymentPhase.PHASE_3
+        assert cm.allocated_capital == Decimal("10000")
+        assert len(cm.phase_history) == 2
+
+
+# ===========================================================================
+# CapitalManager — Halt
+# ===========================================================================
+
+
+class TestHalt:
+    def test_halt(self):
+        cm = CapitalManager()
+        cm.start_phase_1()
+        cm.halt(reason="test")
+        assert cm.current_phase == DeploymentPhase.HALTED
+        assert cm.current_metrics is None
+        assert cm.allocated_capital == Decimal("0")
+
+    def test_halt_archives_metrics(self):
+        cm = CapitalManager()
+        cm.start_phase_1()
+        cm.record_trade(won=True, pnl=Decimal("10"))
+        cm.halt()
+        assert len(cm.phase_history) == 1
+
+    def test_halt_when_already_halted(self):
+        cm = CapitalManager()
+        cm.halt()  # No-op, no error
+        assert cm.current_phase == DeploymentPhase.HALTED
+
+
+# ===========================================================================
+# CapitalManager — Report
+# ===========================================================================
+
+
+class TestGetReport:
+    def test_report_halted(self):
+        cm = CapitalManager()
+        report = cm.get_report()
+        assert report["current_phase"] == "halted"
+        assert report["allocated_capital"] == "0"
+        assert report["current_metrics"] is None
+        assert report["phase_history"] == []
+
+    def test_report_active(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        cm.record_trade(won=True, pnl=Decimal("50"))
+        report = cm.get_report()
+        assert report["total_capital"] == "10000"
+        assert report["current_phase"] == "phase_1_5pct"
+        assert Decimal(report["allocated_capital"]) == Decimal("500")
+        assert report["current_metrics"] is not None
+        assert report["current_metrics"]["total_trades"] == 1
+
+    def test_report_with_history(self):
+        cm = CapitalManager(total_capital=Decimal("10000"))
+        cm.start_phase_1()
+        cm.current_metrics.started_at = datetime.now(timezone.utc) - timedelta(days=4)
+        for _ in range(5):
+            cm.record_trade(won=True, pnl=Decimal("10"))
+        cm.advance_phase()
+        report = cm.get_report()
+        assert len(report["phase_history"]) == 1
+        assert report["current_phase"] == "phase_2_25pct"
+
+
+# ===========================================================================
+# ScalingDecision dataclass
+# ===========================================================================
+
+
+class TestScalingDecision:
+    def test_scaling_decision_creation(self):
+        sd = ScalingDecision(
+            can_scale=True,
+            current_phase=DeploymentPhase.PHASE_1,
+            next_phase=DeploymentPhase.PHASE_2,
+            reasons=["All gates passed"],
+        )
+        assert sd.can_scale
+        assert sd.current_phase == DeploymentPhase.PHASE_1
+        assert sd.next_phase == DeploymentPhase.PHASE_2
+
+    def test_default_lists(self):
+        sd = ScalingDecision(
+            can_scale=False,
+            current_phase=DeploymentPhase.PHASE_1,
+            next_phase=None,
+        )
+        assert sd.reasons == []
+        assert sd.blockers == []
+
+
+# ===========================================================================
+# DEFAULT_PHASES config
+# ===========================================================================
+
+
+class TestDefaultPhases:
+    def test_phase_1_config(self):
+        p1 = DEFAULT_PHASES[0]
+        assert p1.phase == DeploymentPhase.PHASE_1
+        assert p1.allocation_pct == Decimal("0.05")
+        assert p1.min_duration_days == 3
+        assert p1.max_drawdown_pct == Decimal("0.05")
+        assert p1.min_trades == 5
+        assert p1.min_win_rate == Decimal("0.40")
+
+    def test_phase_2_config(self):
+        p2 = DEFAULT_PHASES[1]
+        assert p2.phase == DeploymentPhase.PHASE_2
+        assert p2.allocation_pct == Decimal("0.25")
+        assert p2.min_duration_days == 7
+        assert p2.min_trades == 20
+
+    def test_phase_3_config(self):
+        p3 = DEFAULT_PHASES[2]
+        assert p3.phase == DeploymentPhase.PHASE_3
+        assert p3.allocation_pct == Decimal("1.00")
+        assert p3.min_duration_days == 0
+
+
+# ===========================================================================
+# Edge Cases
+# ===========================================================================
+
+
+class TestEdgeCases:
+    def test_unknown_phase_raises(self):
+        cm = CapitalManager()
+        with pytest.raises(ValueError, match="Unknown phase"):
+            cm._get_phase_config(DeploymentPhase.HALTED)
+
+    def test_zero_capital(self):
+        cm = CapitalManager(total_capital=Decimal("0"))
+        alloc = cm.start_phase_1()
+        assert alloc == Decimal("0")
+
+    def test_large_capital(self):
+        cm = CapitalManager(total_capital=Decimal("1000000"))
+        alloc = cm.start_phase_1()
+        assert alloc == Decimal("50000")


### PR DESCRIPTION
## Summary

- **Issue #181**: Implements `CapitalManager` with phased capital scaling (5% → 25% → 100%) with performance gates (duration, trade count, win rate, drawdown, PnL)
- **Issue #182**: Creates comprehensive v2.0 documentation suite under `docs/v2/`

### Capital Deployment (`bot/utils/capital_manager.py`)
- `DeploymentPhase` enum: PHASE_1 (5%), PHASE_2 (25%), PHASE_3 (100%), HALTED
- `PhaseConfig` with configurable allocation, duration, drawdown, trade, and win rate gates
- `CapitalManager` lifecycle: `start_phase_1()` → `record_trade()` → `evaluate_scaling()` → `advance_phase()`
- `ScalingDecision` with reasons/blockers for transparency
- 53 unit tests covering all gates, edge cases, and full 3-phase progression

### Documentation (`docs/v2/`)
- `USER_GUIDE.md` — Installation, configuration, capital deployment, security audit
- `STRATEGY_DOCS.md` — All 4 strategies (SMC, Trend-Follower, Grid, DCA) with parameters
- `TELEGRAM_REFERENCE.md` — All commands, event notifications, multi-bot management
- `TROUBLESHOOTING.md` — Connection, strategy, database, deployment issues
- `API_DOCS.md` — Exchange client, strategy interface, orchestrator, database, events

## Test plan
- [x] 53 capital manager tests pass (`pytest tests/test_capital_manager.py -p no:pdb -v`)
- [x] All 79 tests for production readiness + capital manager pass
- [x] No regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)