### PR TITLE
fix: resolve CI failures - mypy errors and Python 3.12 pandas incompatibility

### DIFF
--- a/bot/orchestrator/health_monitor.py
+++ b/bot/orchestrator/health_monitor.py
@@ -204,11 +204,6 @@ class HealthMonitor:
                 if status == HealthStatus.HEALTHY:
                     status = HealthStatus.DEGRADED
 
-        # Check strategy in ERROR state
-        if strategy.state == StrategyState.ERROR:
-            status = HealthStatus.CRITICAL
-            issues.append(f"Strategy in ERROR state: {strategy.metrics.last_error}")
-
         message = "; ".join(issues) if issues else "All checks passed"
 
         result = HealthCheckResult(

--- a/bot/strategies/dca/dca_engine.py
+++ b/bot/strategies/dca/dca_engine.py
@@ -32,6 +32,7 @@ from decimal import Decimal
 from typing import Any
 
 from bot.strategies.dca.dca_position_manager import (
+    CloseResult,
     DCADeal,
     DCAOrderConfig,
     DCAPositionManager,
@@ -246,7 +247,7 @@ class DCAEngine:
 
         # Step 3: Risk pre-check
         active_deals = self._position_mgr.get_active_deals()
-        current_exposure = sum(d.total_cost for d in active_deals)
+        current_exposure = sum((d.total_cost for d in active_deals), Decimal(0))
         base_cost = self._position_mgr.config.base_order_volume
 
         risk_check = self._risk_mgr.can_open_new_deal(
@@ -389,7 +390,7 @@ class DCAEngine:
         """Record safety order fill (called after exchange order succeeds)."""
         return self._position_mgr.fill_safety_order(deal_id, level, fill_price)
 
-    def close_deal(self, deal_id: str, exit_price: Decimal, reason: str):
+    def close_deal(self, deal_id: str, exit_price: Decimal, reason: str) -> CloseResult:
         """Close a deal (called after exchange sell order succeeds)."""
         result = self._position_mgr.close_deal(deal_id, exit_price, reason)
         self._risk_mgr.record_trade_result(result.realized_profit)

--- a/bot/strategies/dca/dca_position_manager.py
+++ b/bot/strategies/dca/dca_position_manager.py
@@ -607,7 +607,10 @@ class DCAPositionManager:
     @property
     def total_realized_pnl(self) -> Decimal:
         """Total realized profit across all closed deals."""
-        return sum(d.realized_profit for d in self._deals.values() if d.status == DealStatus.CLOSED)
+        return sum(
+            (d.realized_profit for d in self._deals.values() if d.status == DealStatus.CLOSED),
+            Decimal(0),
+        )
 
     # -----------------------------------------------------------------
     # Statistics

--- a/bot/strategies/grid/grid_calculator.py
+++ b/bot/strategies/grid/grid_calculator.py
@@ -239,7 +239,7 @@ class GridCalculator:
         # Use the last `period` true ranges (or all if less)
         use_count = min(period, len(true_ranges))
         recent_tr = true_ranges[-use_count:]
-        atr = sum(recent_tr) / use_count
+        atr = sum(recent_tr, Decimal(0)) / Decimal(use_count)
 
         return atr.quantize(GridCalculator.PRICE_PRECISION, rounding=ROUND_HALF_UP)
 

--- a/bot/strategies/trend_follower_adapter.py
+++ b/bot/strategies/trend_follower_adapter.py
@@ -24,6 +24,7 @@ from bot.strategies.base import (
 )
 from bot.strategies.trend_follower.config import TrendFollowerConfig
 from bot.strategies.trend_follower.entry_logic import SignalType
+from bot.strategies.trend_follower.position_manager import ExitReason as TFExitReason
 from bot.strategies.trend_follower.trend_follower_strategy import TrendFollowerStrategy
 from bot.utils.logger import get_logger
 
@@ -238,7 +239,7 @@ class TrendFollowerAdapter(BaseStrategy):
         self, position_id: str, exit_reason: BaseExitReason, exit_price: Decimal
     ) -> None:
         """Close position via underlying strategy."""
-        self._strategy.close_position(position_id, exit_reason.value, exit_price)
+        self._strategy.close_position(position_id, TFExitReason(exit_reason.value), exit_price)
 
     def get_active_positions(self) -> list[PositionInfo]:
         """Get active positions from underlying strategy."""

--- a/bot/utils/capital_manager.py
+++ b/bot/utils/capital_manager.py
@@ -286,6 +286,7 @@ class CapitalManager:
         if self.current_metrics:
             self.phase_history.append(self.current_metrics)
 
+        assert decision.next_phase is not None  # guaranteed by can_scale being True
         self.current_phase = decision.next_phase
         self.current_metrics = PhaseMetrics(
             phase=self.current_phase,

--- a/bot/utils/config_validator.py
+++ b/bot/utils/config_validator.py
@@ -297,7 +297,7 @@ class ConfigValidator:
 
         return results
 
-    def run_full_validation(self, **kwargs) -> ConfigValidationReport:
+    def run_full_validation(self, **kwargs: Any) -> ConfigValidationReport:
         """Run all validation checks."""
         report = ConfigValidationReport()
         report.results.extend(self.validate_risk_params(**kwargs.get("risk", {})))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "black==24.1.1",
     "ruff>=0.5.0",
     "mypy>=1.8.0",
+    "types-PyYAML>=6.0.0",
     "pre-commit>=3.6.0",
     "ipython>=8.19.0",
 ]
@@ -123,7 +124,15 @@ module = "ccxt.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = "yaml"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = "bot.tests.*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
 ignore_errors = true
 
 [[tool.mypy.overrides]]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ pytest-mock>=3.12.0
 black>=23.12.0
 ruff>=0.1.9
 mypy>=1.8.0
+types-PyYAML>=6.0.0
 pre-commit>=3.6.0
 
 # Development Tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ redis>=5.0.0
 aiogram>=3.3.0
 
 # Data Analysis & Technical Indicators
-pandas>=2.0.0
+pandas>=2.1.0
 numpy>=1.24.0
 smartmoneyconcepts>=0.0.21
 


### PR DESCRIPTION
## Summary

This PR fixes CI failures that were present after PR #256 was merged. The failing checks are:
- **Code Quality Checks (mypy)**: 47 pre-existing type errors in 10 files
- **Run Tests (3.12)**: `ModuleNotFoundError: No module named 'pkg_resources'` when installing pandas

## Root Cause

1. **Tests (3.12) failure**: `requirements.txt` specified `pandas>=2.0.0`, which pip resolved to `pandas==2.0.2` from cache. This version's `setup.py` imports `pkg_resources`, which was removed in Python 3.12. Fix: bump to `pandas>=2.1.0`.

2. **Mypy failures**: 47 type errors were hidden while CI was failing at an earlier `black` step. Once black was fixed in PR #256, mypy ran and revealed these pre-existing errors.

## Changes

### `requirements.txt` / `requirements-dev.txt` / `pyproject.toml`
- Bump `pandas>=2.1.0` (Python 3.12 compatible wheels)
- Add `types-PyYAML>=6.0.0` to dev dependencies (resolves `[import-untyped]` yaml errors)
- Add mypy overrides for `yaml` and `tests.*` modules

### Type error fixes
| File | Error | Fix |
|------|-------|-----|
| `bot/strategies/dca/dca_position_manager.py` | `sum()` returns `Decimal\|Literal[0]` | Use `sum(..., Decimal(0))` |
| `bot/strategies/dca/dca_engine.py` | Same sum issue + missing return type | Fixed sum + added `-> CloseResult` annotation |
| `bot/strategies/grid/grid_calculator.py` | `sum()` / division type mismatch | `sum(..., Decimal(0)) / Decimal(use_count)` |
| `bot/utils/config_validator.py` | `**kwargs` missing type annotation | Added `**kwargs: Any` |
| `bot/utils/capital_manager.py` | `DeploymentPhase\|None` assigned to `DeploymentPhase` | Added `assert next_phase is not None` |
| `bot/orchestrator/health_monitor.py` | Unreachable dead code (`StrategyState.ERROR` check) | Removed dead code block |
| `bot/strategies/trend_follower_adapter.py` | Passing `str` where `ExitReason` expected | Import and convert `TFExitReason(exit_reason.value)` |

## Test plan

- [ ] Code Quality Checks (black, ruff, mypy) pass
- [ ] Run Tests (3.10, 3.11, 3.12) pass
- [ ] No regressions in existing functionality

---
*Fixes CI failures from merged PR #256*

🤖 Generated with [Claude Code](https://claude.com/claude-code)