### PR TITLE
fix: suppress repetitive SMC log spam

### DIFF
--- a/bot/orchestrator/market_regime.py
+++ b/bot/orchestrator/market_regime.py
@@ -179,6 +179,9 @@ class MarketRegimeDetector:
         self._last_analysis: RegimeAnalysis | None = None
         self._regime_history: list[RegimeAnalysis] = []
 
+        # Log-spam suppression
+        self._insufficient_data_count: int = 0
+
     @property
     def last_analysis(self) -> RegimeAnalysis | None:
         """Return the most recent analysis result."""
@@ -206,11 +209,13 @@ class MarketRegimeDetector:
             self.bb_period + self.volume_lookback,
         )
         if len(df) < min_rows:
-            logger.warning(
-                "insufficient_data",
-                required=min_rows,
-                received=len(df),
-            )
+            self._insufficient_data_count += 1
+            if self._insufficient_data_count == 1:
+                logger.warning(
+                    "insufficient_data",
+                    required=min_rows,
+                    received=len(df),
+                )
             return self._unknown_analysis("Insufficient data")
 
         close = df["close"].astype(float)

--- a/bot/strategies/smc/entry_signals.py
+++ b/bot/strategies/smc/entry_signals.py
@@ -144,6 +144,9 @@ class EntrySignalGenerator:
         self.detected_patterns: list[PriceActionPattern] = []
         self.generated_signals: list[SMCSignal] = []
 
+        # Log-spam suppression
+        self._insufficient_data_count: int = 0
+
         logger.info(
             "EntrySignalGenerator initialized", min_rr=min_risk_reward, sl_buffer=sl_buffer_pct
         )
@@ -159,7 +162,9 @@ class EntrySignalGenerator:
             List of SMCSignal objects
         """
         if len(df) < 2:
-            logger.warning("Insufficient data for pattern detection")
+            self._insufficient_data_count += 1
+            if self._insufficient_data_count == 1:
+                logger.warning("Insufficient data for pattern detection")
             return []
 
         self.detected_patterns.clear()

--- a/bot/strategies/smc/market_structure.py
+++ b/bot/strategies/smc/market_structure.py
@@ -88,6 +88,9 @@ class MarketStructureAnalyzer:
         self.current_trend: TrendDirection = TrendDirection.RANGING
         self._swings_df: Optional[pd.DataFrame] = None
 
+        # Log-spam suppression: count warnings, log only first occurrence
+        self._insufficient_data_count: int = 0
+
         logger.info(
             "MarketStructureAnalyzer initialized",
             swing_length=swing_length,
@@ -116,11 +119,13 @@ class MarketStructureAnalyzer:
             Dictionary with structure analysis results
         """
         if len(df) < self.swing_length * 2 + 1:
-            logger.warning(
-                "Insufficient data for structure analysis",
-                required=self.swing_length * 2 + 1,
-                available=len(df),
-            )
+            self._insufficient_data_count += 1
+            if self._insufficient_data_count == 1:
+                logger.warning(
+                    "Insufficient data for structure analysis",
+                    required=self.swing_length * 2 + 1,
+                    available=len(df),
+                )
             return self.get_current_structure()
 
         # Detect swing points

--- a/bot/strategies/smc/smc_strategy.py
+++ b/bot/strategies/smc/smc_strategy.py
@@ -337,6 +337,17 @@ class SMCStrategy:
 
     def reset(self):
         """Reset strategy state (for backtesting)"""
+        # Log suppressed warning summary before resetting
+        suppressed = {
+            "structure_insufficient_data": self.market_structure._insufficient_data_count,
+            "zone_insufficient_data": self.confluence_analyzer._insufficient_data_count,
+            "liquidity_detection_failed": self.confluence_analyzer._liquidity_fail_count,
+            "pattern_insufficient_data": self.signal_generator._insufficient_data_count,
+        }
+        total = sum(suppressed.values())
+        if total > 0:
+            logger.info("smc_warnings_suppressed", count=total, breakdown=suppressed)
+
         self.market_structure = MarketStructureAnalyzer(
             swing_length=self.config.swing_length,
             trend_period=self.config.trend_period,


### PR DESCRIPTION
## Summary
- Add log-once pattern to 5 warning sites across SMC components and MarketRegimeDetector
- Each warning fires only once; subsequent occurrences are suppressed
- On strategy `reset()`, emit `smc_warnings_suppressed count=N` summary
- Expected pipeline log reduction: 1.4 GB → <50 MB for 45-pair runs

### Suppressed warnings:
| Component | Warning | Was |
|-----------|---------|-----|
| MarketStructureAnalyzer | "Insufficient data for structure analysis" | ~34K/run |
| ConfluenceZoneAnalyzer | "Insufficient data for zone analysis" | thousands |
| ConfluenceZoneAnalyzer | "Liquidity detection failed" | ~3.2K/run |
| EntrySignalGenerator | "Insufficient data for pattern detection" | thousands |
| MarketRegimeDetector | "insufficient_data" | thousands |

## Test plan
- [x] 290 existing SMC + orchestrator tests pass (0 regressions)
- [x] black + ruff clean

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)