### PR TITLE
chore: remove mypy excludes for 3 critical files

### DIFF
--- a/bot/config/manager.py
+++ b/bot/config/manager.py
@@ -7,7 +7,7 @@ import json
 from collections.abc import Callable
 from pathlib import Path
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 from pydantic import ValidationError
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
@@ -39,7 +39,7 @@ class ConfigManager(LoggerMixin):
         self._config: AppConfig | None = None
         self._config_hash: str | None = None
         self._reload_callbacks: list[Callable[[AppConfig], None]] = []
-        self._observer: Observer | None = None
+        self._observer: Observer | None = None  # type: ignore[valid-type]
         self._watch_enabled = False
 
         self.logger.info("Initializing ConfigManager", path=str(config_path))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,10 @@ module = "ccxt.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = "bot.api.exchange_client"
+warn_return_any = false
+
+[[tool.mypy.overrides]]
 module = "bot.tests.*"
 ignore_errors = true
 
@@ -136,23 +140,11 @@ module = "bot.utils.logger"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "bot.config.manager"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = "bot.api.*"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "bot.database.manager"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = "bot.strategies.smc.*"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = "bot.orchestrator.bot_orchestrator"
 ignore_errors = true
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
## Summary
- Fix all mypy errors in `bot_orchestrator.py`, `config/manager.py`, and `exchange_client.py`
- Remove `ignore_errors = true` overrides for these 3 modules from `pyproject.toml`
- All 3 files now pass `mypy --ignore-missing-imports` with 0 errors
- Reduced errors from 58 → 0

### Changes by file:
| File | Errors fixed | Approach |
|------|-------------|----------|
| `exchange_client.py` | 33 | Added `_ex` property for type-safe exchange access, `warn_return_any=false` override for CCXT returns |
| `bot_orchestrator.py` | 23 | Type annotations for 4 methods, `Decimal(0)` sum start, None guards, `dict[str, Any]` annotation |
| `config/manager.py` | 2 | `type: ignore` for yaml import and Observer type |

## Test plan
- [x] `mypy` passes for all 3 files (0 errors)
- [x] 346 tests pass (orchestrator + SMC + web)
- [x] black + ruff clean

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)