### PR TITLE
feat: add rate limiting to FastAPI endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,4 @@ passlib[bcrypt]>=1.7.4
 bcrypt>=4.0.0,<5.0.0
 python-multipart>=0.0.6
 pydantic[email]>=2.5.0
+slowapi>=0.1.9

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from bot.database.models import Base
 from web.backend.app import create_app
+from web.backend.rate_limit import limiter
 
 
 @pytest.fixture(scope="session")
@@ -114,6 +115,9 @@ def mock_db_manager(db_engine):
 @pytest_asyncio.fixture
 async def test_app(mock_db_manager, mock_orchestrators):
     """Create test FastAPI application."""
+    # Reset rate limiter storage between tests
+    limiter.reset()
+
     app = create_app()
 
     # Override lifespan state

--- a/tests/web/test_rate_limiting.py
+++ b/tests/web/test_rate_limiting.py
@@ -1,0 +1,105 @@
+"""
+Tests for rate limiting on Web API endpoints.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_login_rate_limit(client: AsyncClient):
+    """Login endpoint should be rate-limited to 5/min."""
+    # Register a user first
+    await client.post(
+        "/api/v1/auth/register",
+        json={
+            "username": "ratelimit_user",
+            "email": "rl@example.com",
+            "password": "securepass123",
+        },
+    )
+
+    # Make 5 requests (should all succeed or return 401)
+    for _ in range(5):
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "ratelimit_user", "password": "securepass123"},
+        )
+        assert resp.status_code in (200, 401)
+
+    # 6th request should be rate-limited
+    resp = await client.post(
+        "/api/v1/auth/login",
+        json={"username": "ratelimit_user", "password": "securepass123"},
+    )
+    assert resp.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_register_rate_limit(client: AsyncClient):
+    """Register endpoint should be rate-limited to 5/min."""
+    for i in range(5):
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={
+                "username": f"rl_reg_{i}",
+                "email": f"rl_reg_{i}@example.com",
+                "password": "securepass123",
+            },
+        )
+        assert resp.status_code in (201, 409)
+
+    # 6th request should be rate-limited
+    resp = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "username": "rl_reg_overflow",
+            "email": "overflow@example.com",
+            "password": "securepass123",
+        },
+    )
+    assert resp.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_refresh_rate_limit(client: AsyncClient):
+    """Refresh endpoint should be rate-limited to 5/min."""
+    # 5 invalid refreshes (401s count towards the limit)
+    for _ in range(5):
+        resp = await client.post(
+            "/api/v1/auth/refresh",
+            json={"refresh_token": "fake-token"},
+        )
+        assert resp.status_code == 401
+
+    # 6th should be rate-limited
+    resp = await client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": "fake-token"},
+    )
+    assert resp.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_returns_retry_after(client: AsyncClient):
+    """Rate-limited responses should include Retry-After header."""
+    for _ in range(5):
+        await client.post(
+            "/api/v1/auth/login",
+            json={"username": "nouser", "password": "nopass123456"},
+        )
+
+    resp = await client.post(
+        "/api/v1/auth/login",
+        json={"username": "nouser", "password": "nopass123456"},
+    )
+    assert resp.status_code == 429
+    assert "retry-after" in resp.headers
+
+
+@pytest.mark.asyncio
+async def test_health_not_rate_limited_at_5(client: AsyncClient):
+    """Health endpoint uses default 60/min, not the auth 5/min limit."""
+    for _ in range(10):
+        resp = await client.get("/health")
+        assert resp.status_code == 200

--- a/web/backend/auth/router.py
+++ b/web/backend/auth/router.py
@@ -29,12 +29,15 @@ from web.backend.auth.service import (
 )
 from web.backend.config import web_config
 from web.backend.dependencies import get_current_user, get_db
+from web.backend.rate_limit import limiter
 
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
 
 
 @router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+@limiter.limit("5/minute")
 async def register(
+    request: Request,
     data: RegisterRequest,
     db: AsyncSession = Depends(get_db),
 ):
@@ -62,6 +65,7 @@ async def register(
 
 
 @router.post("/login", response_model=TokenResponse)
+@limiter.limit("5/minute")
 async def login(
     data: LoginRequest,
     request: Request,
@@ -103,6 +107,7 @@ async def login(
 
 
 @router.post("/refresh", response_model=TokenResponse)
+@limiter.limit("5/minute")
 async def refresh(
     data: RefreshRequest,
     request: Request,

--- a/web/backend/rate_limit.py
+++ b/web/backend/rate_limit.py
@@ -1,0 +1,14 @@
+"""
+Shared rate limiter for the Web API.
+
+Auth endpoints: 5 req/min per IP
+All other endpoints: 60 req/min per IP (default)
+"""
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=["60/minute"],
+)


### PR DESCRIPTION
## Summary
- Auth endpoints (`/login`, `/register`, `/refresh`): **5 req/min per IP** via `@limiter.limit("5/minute")`
- All other API endpoints: **60 req/min per IP** via `SlowAPIMiddleware` with `default_limits`
- 429 responses include `Retry-After` header
- Shared `Limiter` singleton in `web/backend/rate_limit.py`
- Added `slowapi>=0.1.9` to `requirements.txt`

## Test plan
- [x] 5 new rate limiting tests (`tests/web/test_rate_limiting.py`)
- [x] All 60 web tests pass
- [x] All 1557 tests pass (load tests disable rate limiter to test throughput)

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)