### PR TITLE
security: add Redis password authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,8 @@ DB_PORT=5432
 # Redis Configuration
 # ============================================
 REDIS_PORT=6379
-# REDIS_URL=redis://localhost:6379
+REDIS_PASSWORD=changeme_redis_password
+# REDIS_URL is auto-generated in docker-compose using REDIS_PASSWORD
 
 # ============================================
 # Bot Configuration

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -102,6 +102,7 @@ services:
     container_name: traderagent-redis-exporter
     environment:
       - REDIS_ADDR=redis:6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-changeme_redis_password}
     ports:
       - "9103:9121"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,13 +26,13 @@ services:
   redis:
     image: redis:7-alpine
     container_name: traderagent-redis
-    command: redis-server --appendonly yes
+    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:-changeme_redis_password}
     ports:
       - "${REDIS_PORT:-6379}:6379"
     volumes:
       - redis_data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-changeme_redis_password}", "ping"]
       interval: 10s
       timeout: 3s
       retries: 5
@@ -51,7 +51,7 @@ services:
       DATABASE_URL: postgresql+asyncpg://${DB_USER:-traderagent}:${DB_PASSWORD:-changeme}@postgres:5432/${DB_NAME:-traderagent}
 
       # Redis
-      REDIS_URL: redis://redis:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD:-changeme_redis_password}@redis:6379
 
       # Config
       CONFIG_PATH: /app/configs/${CONFIG_FILE:-production.yaml}
@@ -96,7 +96,7 @@ services:
     container_name: traderagent-webui-backend
     environment:
       DATABASE_URL: postgresql+asyncpg://${DB_USER:-traderagent}:${DB_PASSWORD:-changeme}@postgres:5432/${DB_NAME:-traderagent}
-      REDIS_URL: redis://redis:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD:-changeme_redis_password}@redis:6379
       JWT_SECRET: ${JWT_SECRET:-change-this-in-production}
       WEB_PORT: 8000
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:5173,http://localhost:80}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,7 +48,7 @@ cd TRADERAGENT
 
 # 2. Configure environment
 cp .env.example .env
-nano .env  # Fill in: DATABASE_URL, ENCRYPTION_KEY, TELEGRAM_BOT_TOKEN
+nano .env  # Fill in: DB_PASSWORD, REDIS_PASSWORD, ENCRYPTION_KEY, TELEGRAM_BOT_TOKEN
 
 # 3. Start infrastructure
 docker compose up -d postgres redis
@@ -301,7 +301,7 @@ Once deployed, use Telegram to manage your bot:
 
 ```bash
 docker compose exec postgres pg_isready
-docker compose exec redis redis-cli ping
+docker compose exec redis redis-cli -a "$REDIS_PASSWORD" ping
 docker compose ps
 ```
 
@@ -432,7 +432,7 @@ docker compose logs bot | tail -50
 docker compose exec postgres psql -U traderagent -c "SELECT 1;"
 
 # Redis connection
-docker compose exec redis redis-cli ping
+docker compose exec redis redis-cli -a "$REDIS_PASSWORD" ping
 
 # Check bot state in DB
 docker compose exec postgres psql -U traderagent -c "SELECT bot_name, saved_at FROM bot_state_snapshots;"


### PR DESCRIPTION
## Summary
- Redis now requires password via `REDIS_PASSWORD` env var (`--requirepass`)
- `docker-compose.yml`: bot and webui-backend REDIS_URL includes password
- `docker-compose.monitoring.yml`: redis-exporter passes REDIS_PASSWORD
- Health check updated to use `-a` flag with password
- `.env.example` and `docs/DEPLOYMENT.md` updated

## Test plan
- [x] 239 web + orchestrator tests pass (no code changes, config-only)
- [x] Backward compatible: defaults to `changeme_redis_password` if REDIS_PASSWORD not set

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)