### PR TITLE
feat: add cooldown guard between strategy switches

### DIFF
--- a/bot/config/schemas.py
+++ b/bot/config/schemas.py
@@ -370,6 +370,12 @@ class BotConfig(BaseModel):
     # Operational settings
     dry_run: bool = Field(default=False, description="Run in simulation mode without real orders")
     auto_start: bool = Field(default=False, description="Auto-start bot on initialization")
+    strategy_switch_cooldown_seconds: int = Field(
+        default=600,
+        ge=0,
+        le=7200,
+        description="Minimum seconds between regime-based strategy switches (0 to disable)",
+    )
 
     @model_validator(mode="after")
     def validate_strategy_config(self) -> "BotConfig":


### PR DESCRIPTION
## Summary
- New `strategy_switch_cooldown_seconds` config parameter (default 600, range 0-7200)
- Switch blocked if last switch occurred within cooldown period
- Logs `strategy_switch_cooldown_active` with remaining seconds when blocked
- First strategy set (from empty) always goes through but starts the cooldown timer
- Same-strategy regime changes don't trigger cooldown

## Test plan
- [x] 7 new cooldown tests in `test_regime_strategy_selection.py`
- [x] 14 existing regime tests still pass (21 total)
- [x] 246 orchestrator + web tests pass

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)