### PR TITLE
fix: apply black formatting and restore test-appropriate warmup_bars

### DIFF
--- a/bot/config/schemas.py
+++ b/bot/config/schemas.py
@@ -436,13 +436,15 @@ class ScannerConfig(BaseModel):
     enabled: bool = Field(default=False, description="Enable market scanner")
     pairs: list[str] = Field(
         default_factory=lambda: [
-            "BTC/USDT", "ETH/USDT", "SOL/USDT", "XRP/USDT", "DOGE/USDT",
+            "BTC/USDT",
+            "ETH/USDT",
+            "SOL/USDT",
+            "XRP/USDT",
+            "DOGE/USDT",
         ],
         description="Trading pairs to scan",
     )
-    interval_minutes: int = Field(
-        default=15, ge=1, le=1440, description="Scan interval in minutes"
-    )
+    interval_minutes: int = Field(default=15, ge=1, le=1440, description="Scan interval in minutes")
     timeframe: str = Field(default="1h", description="OHLCV timeframe for regime analysis")
     ohlcv_limit: int = Field(default=200, ge=50, le=1000, description="OHLCV candles to fetch")
     min_volume_usdt: float = Field(
@@ -481,7 +483,9 @@ class AppConfig(BaseModel):
     )
 
     # Scanner
-    scanner: ScannerConfig = Field(default_factory=ScannerConfig, description="Market scanner configuration")
+    scanner: ScannerConfig = Field(
+        default_factory=ScannerConfig, description="Market scanner configuration"
+    )
 
     # Bots
     bots: list[BotConfig] = Field(default_factory=list, description="Bot configurations")

--- a/bot/orchestrator/bot_orchestrator.py
+++ b/bot/orchestrator/bot_orchestrator.py
@@ -603,9 +603,7 @@ class BotOrchestrator:
             self._last_strategy_switch_at = time.monotonic()
         self._active_strategies = strategies
 
-    async def _graceful_transition(
-        self, deactivated: set[str], new_strategies: set[str]
-    ) -> None:
+    async def _graceful_transition(self, deactivated: set[str], new_strategies: set[str]) -> None:
         """Handle graceful cleanup when strategies are deactivated.
 
         1. Cancel open orders for deactivated strategies
@@ -683,9 +681,7 @@ class BotOrchestrator:
                                 base_amount = float(
                                     Decimal(str(pos.get("size", 0))) / self.current_price
                                 )
-                                side = (
-                                    "sell" if pos.get("direction") == "long" else "buy"
-                                )
+                                side = "sell" if pos.get("direction") == "long" else "buy"
                                 await self.exchange.create_order(
                                     symbol=self.config.symbol,
                                     order_type="market",

--- a/bot/replay/bug_detector.py
+++ b/bot/replay/bug_detector.py
@@ -74,29 +74,45 @@ class BugDetector:
         base = self._exchange._base_balance
 
         if free < 0:
-            self._record("CRITICAL", "balance_negative_free", {
-                "free_balance": str(free),
-                "used_balance": str(used),
-            })
+            self._record(
+                "CRITICAL",
+                "balance_negative_free",
+                {
+                    "free_balance": str(free),
+                    "used_balance": str(used),
+                },
+            )
 
         if used < 0:
-            self._record("CRITICAL", "balance_negative_used", {
-                "free_balance": str(free),
-                "used_balance": str(used),
-            })
+            self._record(
+                "CRITICAL",
+                "balance_negative_used",
+                {
+                    "free_balance": str(free),
+                    "used_balance": str(used),
+                },
+            )
 
         if base < 0:
-            self._record("CRITICAL", "balance_negative_base", {
-                "base_balance": str(base),
-            })
+            self._record(
+                "CRITICAL",
+                "balance_negative_base",
+                {
+                    "base_balance": str(base),
+                },
+            )
 
         # Sanity: total USDT should not exceed 10x initial (could indicate a bug)
         total = free + used
         if total > self._initial_balance * 10:
-            self._record("WARNING", "balance_suspiciously_high", {
-                "total_usdt": str(total),
-                "initial": str(self._initial_balance),
-            })
+            self._record(
+                "WARNING",
+                "balance_suspiciously_high",
+                {
+                    "total_usdt": str(total),
+                    "initial": str(self._initial_balance),
+                },
+            )
 
     def check_orphaned_orders(self, max_candles: int = 500) -> None:
         """Flag limit orders that have been open for too many candles."""
@@ -106,12 +122,16 @@ class BugDetector:
             # 5-min candles → each candle = 300_000 ms
             age_candles = (current_ts - order_ts) / 300_000
             if age_candles > max_candles:
-                self._record("WARNING", "orphaned_order", {
-                    "order_id": oid,
-                    "side": order.get("side"),
-                    "price": order.get("price"),
-                    "age_candles": int(age_candles),
-                })
+                self._record(
+                    "WARNING",
+                    "orphaned_order",
+                    {
+                        "order_id": oid,
+                        "side": order.get("side"),
+                        "price": order.get("price"),
+                        "age_candles": int(age_candles),
+                    },
+                )
 
     def check_state_consistency(self, orchestrator: Any) -> None:
         """
@@ -134,11 +154,15 @@ class BugDetector:
                 ghost_ids.discard(gid)
 
         if ghost_ids:
-            self._record("WARNING", "grid_exchange_mismatch", {
-                "ghost_order_ids": list(ghost_ids),
-                "grid_count": len(grid_ids),
-                "exchange_open_count": len(exchange_open_ids),
-            })
+            self._record(
+                "WARNING",
+                "grid_exchange_mismatch",
+                {
+                    "ghost_order_ids": list(ghost_ids),
+                    "grid_count": len(grid_ids),
+                    "exchange_open_count": len(exchange_open_ids),
+                },
+            )
 
     # =====================================================================
     # Exception capture

--- a/bot/replay/replay_exchange.py
+++ b/bot/replay/replay_exchange.py
@@ -150,14 +150,16 @@ class ReplayExchangeClient:
         order["remaining"] = 0.0
         order["status"] = "closed"
 
-        self._fill_log.append({
-            "order_id": order_id,
-            "side": order["side"],
-            "price": float(fill_price),
-            "amount": float(fill_amount),
-            "fee": float(fee),
-            "timestamp": self._clock.current_time,
-        })
+        self._fill_log.append(
+            {
+                "order_id": order_id,
+                "side": order["side"],
+                "price": float(fill_price),
+                "amount": float(fill_amount),
+                "fee": float(fee),
+                "timestamp": self._clock.current_time,
+            }
+        )
 
         logger.debug(
             "replay_order_filled",
@@ -257,7 +259,7 @@ class ReplayExchangeClient:
                     raise Exception(
                         f"InsufficientFunds: need {cost + fee} USDT, have {self._free_balance}"
                     )
-                self._free_balance -= (cost + fee)
+                self._free_balance -= cost + fee
                 self._base_balance += amount_d
             else:
                 if self._base_balance < amount_d:
@@ -265,7 +267,7 @@ class ReplayExchangeClient:
                         f"InsufficientFunds: need {amount_d} base, have {self._base_balance}"
                     )
                 self._base_balance -= amount_d
-                self._free_balance += (cost - fee)
+                self._free_balance += cost - fee
 
             order = {
                 "id": order_id,
@@ -281,16 +283,24 @@ class ReplayExchangeClient:
             }
             self._order_history[order_id] = order
 
-            self._fill_log.append({
-                "order_id": order_id,
-                "side": side.lower(),
-                "price": float(fill_price),
-                "amount": amount,
-                "fee": float(fee),
-                "timestamp": self._clock.current_time,
-            })
+            self._fill_log.append(
+                {
+                    "order_id": order_id,
+                    "side": side.lower(),
+                    "price": float(fill_price),
+                    "amount": amount,
+                    "fee": float(fee),
+                    "timestamp": self._clock.current_time,
+                }
+            )
 
-            return {"id": order_id, "symbol": symbol, "type": "market", "side": side.lower(), "amount": amount}
+            return {
+                "id": order_id,
+                "symbol": symbol,
+                "type": "market",
+                "side": side.lower(),
+                "amount": amount,
+            }
 
         elif order_type.lower() == "limit":
             if price is None:
@@ -331,7 +341,14 @@ class ReplayExchangeClient:
             # Check if it fills immediately against current candle
             self._match_limit_orders()
 
-            return {"id": order_id, "symbol": symbol, "type": "limit", "side": side.lower(), "amount": amount, "price": price}
+            return {
+                "id": order_id,
+                "symbol": symbol,
+                "type": "limit",
+                "side": side.lower(),
+                "amount": amount,
+                "price": price,
+            }
 
         else:
             raise ValueError(f"Unknown order type: {order_type}")
@@ -433,7 +450,7 @@ class ReplayExchangeClient:
         # Work backwards from end, group into chunks of raw_per_bar
         start = len(raw) - (len(raw) % raw_per_bar) if len(raw) % raw_per_bar != 0 else len(raw)
         for i in range(0, len(raw), raw_per_bar):
-            chunk = raw[i: i + raw_per_bar]
+            chunk = raw[i : i + raw_per_bar]
             if not chunk:
                 continue
             bar = [
@@ -491,8 +508,17 @@ class ReplayExchangeClient:
 def _timeframe_to_minutes(tf: str) -> int:
     """Convert a timeframe string like '1h', '15m', '1d' to minutes."""
     mapping = {
-        "1m": 1, "3m": 3, "5m": 5, "15m": 15, "30m": 30,
-        "1h": 60, "2h": 120, "4h": 240, "6h": 360, "12h": 720,
-        "1d": 1440, "1w": 10080,
+        "1m": 1,
+        "3m": 3,
+        "5m": 5,
+        "15m": 15,
+        "30m": 30,
+        "1h": 60,
+        "2h": 120,
+        "4h": 240,
+        "6h": 360,
+        "12h": 720,
+        "1d": 1440,
+        "1w": 10080,
     }
     return mapping.get(tf, 60)

--- a/bot/replay/simulated_clock.py
+++ b/bot/replay/simulated_clock.py
@@ -74,9 +74,7 @@ def _make_fake_datetime_class(clock: SimulatedClock):
 
         @classmethod
         def utcnow(cls):
-            return datetime.fromtimestamp(clock.current_time, tz=timezone.utc).replace(
-                tzinfo=None
-            )
+            return datetime.fromtimestamp(clock.current_time, tz=timezone.utc).replace(tzinfo=None)
 
     return FakeDatetime
 

--- a/bot/scanner/market_scanner.py
+++ b/bot/scanner/market_scanner.py
@@ -37,9 +37,15 @@ logger = get_logger(__name__)
 class ScannerConfig:
     """Configuration for MarketScanner."""
 
-    pairs: list[str] = field(default_factory=lambda: [
-        "BTC/USDT", "ETH/USDT", "SOL/USDT", "XRP/USDT", "DOGE/USDT",
-    ])
+    pairs: list[str] = field(
+        default_factory=lambda: [
+            "BTC/USDT",
+            "ETH/USDT",
+            "SOL/USDT",
+            "XRP/USDT",
+            "DOGE/USDT",
+        ]
+    )
     interval_minutes: int = 15
     timeframe: str = "1h"
     ohlcv_limit: int = 200

--- a/bot/tests/backtesting/backtesting_engine.py
+++ b/bot/tests/backtesting/backtesting_engine.py
@@ -91,7 +91,9 @@ class BacktestResult:
                 "sortino_ratio": float(self.sortino_ratio) if self.sortino_ratio else None,
                 "calmar_ratio": float(self.calmar_ratio) if self.calmar_ratio else None,
                 "profit_factor": float(self.profit_factor) if self.profit_factor else None,
-                "capital_efficiency": float(self.capital_efficiency) if self.capital_efficiency else None,
+                "capital_efficiency": (
+                    float(self.capital_efficiency) if self.capital_efficiency else None
+                ),
                 "max_position_value": float(self.max_position_value),
             },
             "trade_count": len(self.trade_history),

--- a/bot/tests/backtesting/job_store.py
+++ b/bot/tests/backtesting/job_store.py
@@ -32,8 +32,7 @@ class JobStore:
         """Create the jobs table if it doesn't exist."""
         self._conn = sqlite3.connect(self.db_path)
         self._conn.row_factory = sqlite3.Row
-        self._conn.execute(
-            """
+        self._conn.execute("""
             CREATE TABLE IF NOT EXISTS jobs (
                 job_id TEXT PRIMARY KEY,
                 job_type TEXT NOT NULL,
@@ -44,8 +43,7 @@ class JobStore:
                 created_at TEXT NOT NULL,
                 updated_at TEXT NOT NULL
             )
-            """
-        )
+            """)
         self._conn.commit()
 
     def create(self, job_type: str, config: dict[str, Any] | None = None) -> str:
@@ -84,9 +82,7 @@ class JobStore:
 
     def get(self, job_id: str) -> dict[str, Any] | None:
         """Get a job by ID."""
-        row = self._conn.execute(
-            "SELECT * FROM jobs WHERE job_id = ?", (job_id,)
-        ).fetchone()
+        row = self._conn.execute("SELECT * FROM jobs WHERE job_id = ?", (job_id,)).fetchone()
         if row is None:
             return None
         return self._row_to_dict(row)
@@ -118,9 +114,7 @@ class JobStore:
     def cleanup_old(self, days: int = 30) -> int:
         """Delete jobs older than N days. Returns count deleted."""
         cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
-        cursor = self._conn.execute(
-            "DELETE FROM jobs WHERE created_at < ?", (cutoff,)
-        )
+        cursor = self._conn.execute("DELETE FROM jobs WHERE created_at < ?", (cutoff,))
         self._conn.commit()
         return cursor.rowcount
 

--- a/bot/tests/backtesting/multi_tf_engine.py
+++ b/bot/tests/backtesting/multi_tf_engine.py
@@ -311,7 +311,10 @@ class MultiTimeframeBacktestEngine:
             if self._risk_manager:
                 self._risk_manager.update_balance(portfolio_value)
                 # Daily reset every N bars (simulates UTC midnight)
-                if bars_since_warmup > 0 and bars_since_warmup % self.config.rm_daily_loss_reset_bars == 0:
+                if (
+                    bars_since_warmup > 0
+                    and bars_since_warmup % self.config.rm_daily_loss_reset_bars == 0
+                ):
                     self._risk_manager.reset_daily_loss()
                 if self._risk_manager.is_halted:
                     break
@@ -338,9 +341,7 @@ class MultiTimeframeBacktestEngine:
                 self._regime_filter_blocks += 1
                 return
             strategy_type = strategy.get_strategy_type()
-            allowed_types = REGIME_ALLOWED_STRATEGY_TYPES.get(
-                self._current_regime.regime, set()
-            )
+            allowed_types = REGIME_ALLOWED_STRATEGY_TYPES.get(self._current_regime.regime, set())
             if allowed_types and strategy_type not in allowed_types:
                 self._regime_filter_blocks += 1
                 return
@@ -531,9 +532,7 @@ class MultiTimeframeBacktestEngine:
         # Calmar ratio
         calmar_ratio = None
         if max_drawdown_pct > 0:
-            calmar_ratio = (total_return_pct / Decimal("100")) / (
-                max_drawdown_pct / Decimal("100")
-            )
+            calmar_ratio = (total_return_pct / Decimal("100")) / (max_drawdown_pct / Decimal("100"))
 
         # Profit factor
         profit_factor = None

--- a/bot/tests/backtesting/optimization.py
+++ b/bot/tests/backtesting/optimization.py
@@ -112,9 +112,9 @@ class OptimizationResult:
                 continue
 
             val_mean = sum(values) / len(values)
-            cov = sum(
-                (v - val_mean) * (o - obj_mean) for v, o in zip(values, objectives)
-            ) / len(values)
+            cov = sum((v - val_mean) * (o - obj_mean) for v, o in zip(values, objectives)) / len(
+                values
+            )
             std_v = (sum((v - val_mean) ** 2 for v in values) / len(values)) ** 0.5
             std_o = (sum((o - obj_mean) ** 2 for o in objectives) / len(objectives)) ** 0.5
 
@@ -172,13 +172,20 @@ class ParameterOptimizer:
 
         if max_workers and max_workers > 1:
             trials = await self._run_trials_parallel(
-                combinations, strategy_factory, data, max_workers,
-                run_id=run_id, completed=completed,
+                combinations,
+                strategy_factory,
+                data,
+                max_workers,
+                run_id=run_id,
+                completed=completed,
             )
         else:
             trials = await self._run_trials_sequential(
-                combinations, strategy_factory, data,
-                run_id=run_id, completed=completed,
+                combinations,
+                strategy_factory,
+                data,
+                run_id=run_id,
+                completed=completed,
             )
 
         # Sort by objective
@@ -229,9 +236,7 @@ class ParameterOptimizer:
             OptimizationResult with combined trials from both phases.
         """
         # Phase 1: Coarse search
-        coarse_grid = {
-            k: self._sample_evenly(v, coarse_steps) for k, v in param_grid.items()
-        }
+        coarse_grid = {k: self._sample_evenly(v, coarse_steps) for k, v in param_grid.items()}
         coarse_result = await self.optimize(
             strategy_factory, coarse_grid, data, max_workers=max_workers
         )
@@ -347,8 +352,7 @@ class ParameterOptimizer:
             from bot.tests.backtesting.checkpoint import OptimizationCheckpoint
 
             combos_to_run = [
-                p for p in combinations
-                if OptimizationCheckpoint.config_hash(p) not in completed
+                p for p in combinations if OptimizationCheckpoint.config_hash(p) not in completed
             ]
 
         loop = asyncio.get_event_loop()

--- a/bot/tests/backtesting/stress_testing.py
+++ b/bot/tests/backtesting/stress_testing.py
@@ -66,9 +66,7 @@ class StressTestResult:
         """Average return across stress periods."""
         if not self.periods:
             return 0.0
-        return sum(float(p.result.total_return_pct) for p in self.periods) / len(
-            self.periods
-        )
+        return sum(float(p.result.total_return_pct) for p in self.periods) / len(self.periods)
 
 
 class StressTester:
@@ -124,9 +122,7 @@ class StressTester:
         # Select top N non-overlapping windows
         selected: list[tuple[int, int, float]] = []
         for start, end, vol in windows:
-            overlaps = any(
-                not (end <= s or start >= e) for s, e, _ in selected
-            )
+            overlaps = any(not (end <= s or start >= e) for s, e, _ in selected)
             if not overlaps:
                 selected.append((start, end, vol))
             if len(selected) >= config.num_periods:

--- a/bot/tests/backtesting/test_advanced_analytics.py
+++ b/bot/tests/backtesting/test_advanced_analytics.py
@@ -991,9 +991,7 @@ class TestRankingsNewMetrics:
         from bot.tests.backtesting.strategy_comparison import StrategyComparison
 
         data = _load_test_data(days=4)
-        comparison = StrategyComparison(
-            config=MultiTFBacktestConfig(warmup_bars=20)
-        )
+        comparison = StrategyComparison(config=MultiTFBacktestConfig(warmup_bars=20))
         s1 = SimpleTestStrategy(buy_every_n=5, name="s1")
         s2 = SimpleTestStrategy(buy_every_n=10, name="s2")
         result = await comparison.run([s1, s2], data)
@@ -1006,9 +1004,7 @@ class TestRankingsNewMetrics:
         from bot.tests.backtesting.strategy_comparison import StrategyComparison
 
         data = _load_test_data(days=4)
-        comparison = StrategyComparison(
-            config=MultiTFBacktestConfig(warmup_bars=20)
-        )
+        comparison = StrategyComparison(config=MultiTFBacktestConfig(warmup_bars=20))
         s1 = SimpleTestStrategy(buy_every_n=5, name="s1")
         result = await comparison.run([s1], data)
 

--- a/bot/tests/backtesting/test_multi_tf_backtesting.py
+++ b/bot/tests/backtesting/test_multi_tf_backtesting.py
@@ -544,7 +544,7 @@ class TestSMCAdapterIntegration:
         config = MultiTFBacktestConfig(
             symbol="BTC/USDT",
             initial_balance=Decimal("10000"),
-            warmup_bars=14400,
+            warmup_bars=60,
         )
         engine = MultiTimeframeBacktestEngine(config=config)
         strategy = SMCStrategyAdapter(
@@ -574,7 +574,7 @@ class TestTrendFollowerAdapterIntegration:
         config = MultiTFBacktestConfig(
             symbol="BTC/USDT",
             initial_balance=Decimal("10000"),
-            warmup_bars=14400,
+            warmup_bars=60,
         )
         engine = MultiTimeframeBacktestEngine(config=config)
         strategy = TrendFollowerAdapter(
@@ -687,9 +687,7 @@ class TestIntraCandleSweep:
             taker_fee=Decimal("0"),
             slippage=Decimal("0"),
         )
-        await sim.set_candle(
-            Decimal("100"), Decimal("110"), Decimal("90"), Decimal("105")
-        )
+        await sim.set_candle(Decimal("100"), Decimal("110"), Decimal("90"), Decimal("105"))
         assert sim.current_price == Decimal("105")
 
     async def test_limit_buy_fills_on_low(self):
@@ -707,9 +705,7 @@ class TestIntraCandleSweep:
         assert len(sim.get_open_orders()) == 1
 
         # Candle sweeps O=100, L=90, H=110, C=105 — low touches 90 < 95
-        await sim.set_candle(
-            Decimal("100"), Decimal("110"), Decimal("90"), Decimal("105")
-        )
+        await sim.set_candle(Decimal("100"), Decimal("110"), Decimal("90"), Decimal("105"))
         assert len(sim.get_open_orders()) == 0
         assert sim.balance.base == Decimal("1")
 
@@ -729,9 +725,7 @@ class TestIntraCandleSweep:
         assert len(sim.get_open_orders()) == 1
 
         # Candle sweeps O=100, L=90, H=110, C=105 — high 110 >= 108
-        await sim.set_candle(
-            Decimal("100"), Decimal("110"), Decimal("90"), Decimal("105")
-        )
+        await sim.set_candle(Decimal("100"), Decimal("110"), Decimal("90"), Decimal("105"))
         assert len(sim.get_open_orders()) == 0
         assert sim.balance.base == Decimal("0")
 
@@ -744,9 +738,7 @@ class TestIntraCandleSweep:
             taker_fee=Decimal("0"),
             slippage=Decimal("0"),
         )
-        await sim.set_candle(
-            Decimal("100"), Decimal("110"), Decimal("90"), Decimal("105")
-        )
+        await sim.set_candle(Decimal("100"), Decimal("110"), Decimal("90"), Decimal("105"))
         await sim.create_order("BTC/USDT", "market", "buy", Decimal("1"))
         # Market order executes at current_price = 105 (close)
         assert sim.balance.base == Decimal("1")

--- a/bot/tests/backtesting/test_persistence.py
+++ b/bot/tests/backtesting/test_persistence.py
@@ -17,7 +17,6 @@ from bot.tests.backtesting.checkpoint import OptimizationCheckpoint
 from bot.tests.backtesting.job_store import JobStore
 from bot.tests.backtesting.preset_export import PresetExporter
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/bot/tests/backtesting/test_regime_risk_integration.py
+++ b/bot/tests/backtesting/test_regime_risk_integration.py
@@ -24,7 +24,6 @@ from bot.tests.backtesting.multi_tf_engine import (
 # Reuse ConcreteStrategy from existing tests
 from tests.strategies.test_base_strategy import ConcreteStrategy
 
-
 # =============================================================================
 # Helpers
 # =============================================================================
@@ -124,12 +123,8 @@ class TestRegimeFilterBlocksWrongStrategy:
         strategy = ConcreteStrategy()  # strategy_type = "test"
 
         # Force regime to BULL_TREND (allowed: trend_follower, dca — NOT "test")
-        forced_regime = _make_regime_analysis(
-            MarketRegime.BULL_TREND, RecommendedStrategy.DCA
-        )
-        with patch.object(
-            MarketRegimeDetector, "analyze", return_value=forced_regime
-        ):
+        forced_regime = _make_regime_analysis(MarketRegime.BULL_TREND, RecommendedStrategy.DCA)
+        with patch.object(MarketRegimeDetector, "analyze", return_value=forced_regime):
             result = await engine.run(strategy, data_30days)
 
         # "test" not in BULL_TREND allowed types, so signals should be blocked
@@ -152,12 +147,8 @@ class TestRegimeFilterAllowsMatchingStrategy:
         strategy.get_strategy_type = lambda: "dca"  # type: ignore[assignment]
 
         # Force BEAR_TREND (allowed: dca, trend_follower)
-        forced_regime = _make_regime_analysis(
-            MarketRegime.BEAR_TREND, RecommendedStrategy.DCA
-        )
-        with patch.object(
-            MarketRegimeDetector, "analyze", return_value=forced_regime
-        ):
+        forced_regime = _make_regime_analysis(MarketRegime.BEAR_TREND, RecommendedStrategy.DCA)
+        with patch.object(MarketRegimeDetector, "analyze", return_value=forced_regime):
             result = await engine.run(strategy, data_30days)
 
         # dca IS allowed in BEAR_TREND — no regime blocks expected
@@ -191,9 +182,7 @@ class TestHoldAndReduceExposureBlockAll:
         engine = MultiTimeframeBacktestEngine(config=config)
         strategy = ConcreteStrategy()
 
-        forced = _make_regime_analysis(
-            MarketRegime.QUIET_TRANSITION, RecommendedStrategy.HOLD
-        )
+        forced = _make_regime_analysis(MarketRegime.QUIET_TRANSITION, RecommendedStrategy.HOLD)
         with patch.object(MarketRegimeDetector, "analyze", return_value=forced):
             result = await engine.run(strategy, data_30days)
 

--- a/bot/tests/unit/test_config_manager.py
+++ b/bot/tests/unit/test_config_manager.py
@@ -42,14 +42,12 @@ class TestConfigManager:
     def test_load_invalid_schema(self, test_config_dir: Path):
         """Test loading YAML with invalid schema"""
         invalid_file = test_config_dir / "invalid_schema.yaml"
-        invalid_file.write_text(
-            """
+        invalid_file.write_text("""
 database_url: postgresql://test
 log_level: INVALID_LEVEL
 encryption_key: test
 bots: []
-"""
-        )
+""")
 
         manager = ConfigManager(invalid_file)
 


### PR DESCRIPTION
## Summary

Fixes CI failures introduced by PR #307:

- **Code Quality Checks (black)**: Applied `black` formatter to 16 files in `bot/` that had formatting inconsistencies. The CI was failing because `black --check bot/` found 14 files needing reformatting.

- **Run Tests (3.11) backtesting**: Restored `warmup_bars=60` in `TestSMCAdapterIntegration` and `TestTrendFollowerAdapterIntegration` integration tests.
  - **Root cause**: PR #307 changed these values from `60` → `14400` to match the new production default. However, these integration tests only generate 4-14 days of synthetic data (1,152–4,032 M5 bars), far below the 14,400-bar warmup threshold. With `warmup_bars=14400`, no bars were processed after warmup, leaving `equity_curve=[]` and causing `AssertionError: assert 0 > 0`.
  - The production default `warmup_bars=14400` in `MultiTFBacktestConfig` is **correct and unchanged**.
  - These integration tests verify that adapters wire into the engine correctly — not production warmup behavior — so a smaller test-appropriate warmup value (60 bars) is appropriate.

## Test plan

- [x] `black --check bot/` passes (129 files unchanged)
- [x] `ruff check bot/` error count does not increase (15 errors vs 17 before, pre-existing only)
- [ ] `pytest bot/tests/backtesting/test_multi_tf_backtesting.py::TestSMCAdapterIntegration::test_smc_adapter_backtest` passes
- [ ] `pytest bot/tests/backtesting/test_multi_tf_backtesting.py::TestTrendFollowerAdapterIntegration::test_trend_follower_backtest` passes
- [ ] Full CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)