### PR TITLE
fix(ci): apply black formatting and fix ruff errors after PR #363 merge

### DIFF
--- a/bot/core/portfolio_risk_manager.py
+++ b/bot/core/portfolio_risk_manager.py
@@ -30,10 +30,11 @@ Usage:
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass, field
+from collections.abc import Callable
+from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Callable, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from bot.utils.logger import get_logger
 
@@ -325,8 +326,7 @@ class PortfolioRiskManager:
                 status=RiskCheckStatus.REJECTED_SYMBOL_COOLDOWN,
                 approved=False,
                 reason=(
-                    f"Symbol {symbol} is in cooldown after force-close "
-                    f"({remaining}s remaining)"
+                    f"Symbol {symbol} is in cooldown after force-close " f"({remaining}s remaining)"
                 ),
             )
 
@@ -432,9 +432,7 @@ class PortfolioRiskManager:
         if symbol not in self._symbol_providers:
             return
         self._symbol_providers[symbol] = [
-            (name, p)
-            for name, p in self._symbol_providers[symbol]
-            if name != strategy_name
+            (name, p) for name, p in self._symbol_providers[symbol] if name != strategy_name
         ]
 
     # ------------------------------------------------------------------

--- a/bot/orchestrator/bot_orchestrator.py
+++ b/bot/orchestrator/bot_orchestrator.py
@@ -1326,9 +1326,7 @@ class BotOrchestrator:
 
         # Per-symbol global stop-loss check (PortfolioRiskManager)
         if self._portfolio_rm is not None:
-            triggered = self._portfolio_rm.tick_global_stop_loss(
-                symbols=[str(self.config.symbol)]
-            )
+            triggered = self._portfolio_rm.tick_global_stop_loss(symbols=[str(self.config.symbol)])
             for symbol in triggered:
                 logger.critical(
                     "global_stop_loss_force_close",


### PR DESCRIPTION
## Summary

After PR #363 was merged, two files still fail the `black --check` CI step:
- `bot/core/portfolio_risk_manager.py`
- `bot/orchestrator/bot_orchestrator.py`

Additionally, `portfolio_risk_manager.py` had two ruff linting errors:
- **UP035**: `Callable` should be imported from `collections.abc`, not `typing`
- **F401**: `field` from `dataclasses` was imported but unused

This PR fixes all remaining CI failures on the current `main` branch.

## Changes

- Applied `black` formatting to `bot/core/portfolio_risk_manager.py` and `bot/orchestrator/bot_orchestrator.py`
- Moved `Callable` import from `typing` to `collections.abc` (ruff UP035)
- Removed unused `field` import from `dataclasses` (ruff F401)

## Test plan

- [x] `black --check bot/` passes with "146 files would be left unchanged"
- [x] `ruff check bot/` passes with "All checks passed!"
- [x] All 1672 local tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)